### PR TITLE
Adding shell runnable condition to system_prompt for the stubborn llm

### DIFF
--- a/src/fish_ai/engine.py
+++ b/src/fish_ai/engine.py
@@ -57,7 +57,7 @@ def get_system_prompt():
         'role': 'system',
         'content': '''
         You are a shell scripting assistant working inside a fish shell.
-        The operating system is {os}.
+        The operating system is {os}. Your output must to be shell runnable.
         You may consult Stack Overflow and the official Fish shell
         documentation for answers. If you are unable to fulfill the request,
         respond with a short message starting with "error: ".


### PR DESCRIPTION

Added condition: "Your output must to be shell runnable." To avoid output that is not shell compliant. Especially for the self-hosted llama3-7b seems to become quite chatty otherwise.

(Update engine.py )
