### PR TITLE
feat: redact sensitive information

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ should run on [any system with Python and git installed](https://github.com/Real
 Originally based on [Tom Dörr's `fish.codex` repository](https://github.com/tom-doerr/codex.fish),
 but with some additional functionality.
 
-It can be hooked up to OpenAI, Azure OpenAI, Google, HuggingFace, Mistral or a
+It can be hooked up to OpenAI, Azure OpenAI, Google, Hugging Face, Mistral or a
 self-hosted LLM behind any OpenAI-compatible API.
 
 If you like it, please add a ⭐. If you don't like it, create a PR. 😆
@@ -244,6 +244,18 @@ to the LLM.
 
 If you are concerned with data privacy, you should use a self-hosted
 LLM. When hosted locally, no data ever leaves your machine.
+
+### Redaction of sensitive information
+
+The plugin attempts to redact sensitive information from the prompt
+before submitting it to the LLM. Sensitive information is replaced by
+the `<REDACTED>` placeholder.
+
+The following information is redacted:
+
+- Passwords and API keys supplied on the commandline.
+- Base64 encoded data in single or double quotes.
+- PEM-encoded private keys.
 
 ## 🔨 Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fish_ai"
-version = "0.8.0"
+version = "0.9.0"
 authors = [{ name = "Bastian Fredriksson", email = "realiserad@gmail.com" }]
 description = "Provides core functionality for fish-ai, an AI plugin for the fish shell."
 readme = "README.md"

--- a/src/fish_ai/engine.py
+++ b/src/fish_ai/engine.py
@@ -18,6 +18,7 @@ from hugchat import hugchat
 from hugchat.login import Login
 from mistralai.client import MistralClient
 from mistralai.models.chat_completion import ChatMessage
+from fish_ai.redact import redact
 
 config = ConfigParser()
 config.read(path.expanduser('~/.config/fish-ai.ini'))
@@ -197,6 +198,8 @@ def create_system_prompt(messages):
 
 
 def get_response(messages):
+    messages = redact(messages)
+
     start_time = time_ns()
 
     if get_config('provider') == 'google':

--- a/src/fish_ai/redact.py
+++ b/src/fish_ai/redact.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+import re
+
+
+def redact(messages):
+    for message in messages:
+        message['content'] = redact_content(message['content'])
+    return messages
+
+
+def redact_content(content):
+    r = content
+    r = redact_cli_parameter('api-key', r)
+    r = redact_cli_parameter('password', r)
+    r = redact_cli_parameter('passphrase', r)
+    r = redact_cli_parameter('secret', r)
+    r = redact_pem_encoded_private_key(r)
+    r = redact_pem_encoded_private_key_block(r)
+    r = redact_base64_data(r)
+    return r
+
+
+def redact_cli_parameter(param, content):
+    pattern = r'--{param}([= ]?)(["\']?)\S+\2'.format(
+        param=param)
+    replace_with = r'--{param}\1\2<REDACTED>\2'.format(
+        param=param)
+    return re.sub(
+        pattern,
+        replace_with,
+        content)
+
+
+def redact_pem_encoded_private_key(content):
+    pattern = (r'-----BEGIN ([A-Z0-9]+) PRIVATE KEY-----\n'
+               r'[\s\S]+\n'
+               r'-----END \1 PRIVATE KEY-----')
+    replace_with = (r'-----BEGIN \1 PRIVATE KEY-----\n'
+                    r'<REDACTED>\n'
+                    r'-----END \1 PRIVATE KEY-----')
+    return re.sub(
+        pattern,
+        replace_with,
+        content,
+        flags=re.DOTALL)
+
+
+def redact_pem_encoded_private_key_block(content):
+    pattern = (r'-----BEGIN ([A-Z0-9]+) PRIVATE KEY BLOCK-----\n'
+               r'[\s\S]+\n'
+               r'-----END \1 PRIVATE KEY BLOCK-----')
+    replace_with = (r'-----BEGIN \1 PRIVATE KEY BLOCK-----\n'
+                    r'<REDACTED>\n'
+                    r'-----END \1 PRIVATE KEY BLOCK-----')
+    return re.sub(
+        pattern,
+        replace_with,
+        content,
+        flags=re.DOTALL)
+
+
+def redact_base64_data(content):
+    pattern = r'["\']([A-Za-z0-9+\\/=]+={0,2})["\']'
+    replace_with = r'"<REDACTED>"'
+    return re.sub(
+        pattern,
+        replace_with,
+        content)

--- a/src/fish_ai/tests/redact_test.py
+++ b/src/fish_ai/tests/redact_test.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+
+from fish_ai.redact import redact_content
+import textwrap
+
+
+def test_redact_api_key():
+    input_str = '--api-key=sk-1234'
+    expected_output = '--api-key=<REDACTED>'
+    assert redact_content(input_str) == expected_output
+
+    input_str = '--api-key sk-1234'
+    expected_output = '--api-key <REDACTED>'
+    assert redact_content(input_str) == expected_output
+
+    input_str = "--api-key 'sk-1234'"
+    expected_output = "--api-key '<REDACTED>'"
+    assert redact_content(input_str) == expected_output
+
+    input_str = '--api-key "sk-1234"'
+    expected_output = '--api-key "<REDACTED>"'
+    assert redact_content(input_str) == expected_output
+
+
+def test_redact_password():
+    input_str = 'login --username foo --password=samba123'
+    expected_output = 'login --username foo --password=<REDACTED>'
+    assert redact_content(input_str) == expected_output
+
+    input_str = 'login --username foo --password samba123'
+    expected_output = 'login --username foo --password <REDACTED>'
+    assert redact_content(input_str) == expected_output
+
+    input_str = "login --username foo --password 'samba123'"
+    expected_output = "login --username foo --password '<REDACTED>'"
+    assert redact_content(input_str) == expected_output
+
+    input_str = 'login --username foo --password "samba123!"'
+    expected_output = 'login --username foo --password "<REDACTED>"'
+    assert redact_content(input_str) == expected_output
+
+
+def test_redact_multiple_cli_parameters():
+    input_str = textwrap.dedent("""\
+        Here are some login commands for cucumber, tomato and pepper:
+
+        login --username cucumber --password cucumber
+        login --username tomato --api-key tomato
+        echo 'cGVwcGVy' | login --username pepper""")
+    expected_output = textwrap.dedent("""\
+        Here are some login commands for cucumber, tomato and pepper:
+
+        login --username cucumber --password <REDACTED>
+        login --username tomato --api-key <REDACTED>
+        echo \"<REDACTED>\" | login --username pepper""")
+    assert redact_content(input_str) == expected_output
+
+
+def test_redact_base64_data():
+    input_str = 'echo "cGFzc3dvcmQxMjM=" | login'
+    expected_output = 'echo "<REDACTED>" | login'
+    assert redact_content(input_str) == expected_output
+
+    input_str = "echo 'cGFzc3dvcmQxMjM=' | login"
+    expected_output = 'echo "<REDACTED>" | login'
+    assert redact_content(input_str) == expected_output
+
+
+def test_redact_pem_encoded_private_key():
+    input_str = textwrap.dedent("""\
+        -----BEGIN RSA PRIVATE KEY-----
+        Proc-Type: 4,ENCRYPTED
+        DEK-Info: DES-EDE3-CBC,B1F1B3F5F1B4F1B3
+        6+jVglcOq6vNfwt/Q+X9m
+        -----END RSA PRIVATE KEY-----""")
+    expected_output = textwrap.dedent("""\
+        -----BEGIN RSA PRIVATE KEY-----
+        <REDACTED>
+        -----END RSA PRIVATE KEY-----""")
+    assert redact_content(input_str) == expected_output
+
+
+def test_redact_content():
+    input_str = textwrap.dedent("""\
+        Autocomplete the following command:
+
+        key import --file key.pem --password samba123
+
+        You may use the following command line history to personalize the
+        response:
+
+        key import --file key.pem --password samba123 --server server1.com
+        key import --file key.pem --password samba123 --server server2.com
+
+        The content of key.pem is:
+
+        -----BEGIN PGP PRIVATE KEY BLOCK-----
+        123456789123456789012345678901234567890123456789012345678901234
+        123456789123456789012345678901234567890123456789012345678901234
+        123456789123456789012345678901234567890123456789012345678901234
+        -----END PGP PRIVATE KEY BLOCK-----""")
+    expected_output = textwrap.dedent("""\
+        Autocomplete the following command:
+
+        key import --file key.pem --password <REDACTED>
+
+        You may use the following command line history to personalize the
+        response:
+
+        key import --file key.pem --password <REDACTED> --server server1.com
+        key import --file key.pem --password <REDACTED> --server server2.com
+
+        The content of key.pem is:
+
+        -----BEGIN PGP PRIVATE KEY BLOCK-----
+        <REDACTED>
+        -----END PGP PRIVATE KEY BLOCK-----""")
+    assert redact_content(input_str) == expected_output
+
+
+def test_nothing_to_redact():
+    input_str = 'Nothing to redact here...'
+    assert redact_content(input_str) == input_str


### PR DESCRIPTION
Redact sensitive information from the prompt before sending it to the LLM, such as passwords and private keys.