### PR TITLE
Add model to Ollama config

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ configuration = local-llama
 
 [local-llama]
 provider = self-hosted
+model = llama3.1
 server = http://localhost:11434/v1
 ```
 


### PR DESCRIPTION
I got my fish-ai working with Ollama by providing the model key and value. It defaulted to gpt-4o and created an error. This is on macOS.