### PR TITLE
feat: provider for anthropic

### DIFF
--- a/.devcontainer/requirements-dev.txt
+++ b/.devcontainer/requirements-dev.txt
@@ -12,3 +12,4 @@ hugchat
 mistralai
 binaryornot
 azure-ai-inference
+anthropic

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Originally based on [Tom Dörr's `fish.codex` repository](https://github.com/tom
 but with some additional functionality.
 
 It can be hooked up to OpenAI, Azure OpenAI, Google, Hugging Face, Mistral,
-GitHub or a self-hosted LLM behind any OpenAI-compatible API.
+Anthropic, GitHub or a self-hosted LLM behind any OpenAI-compatible API.
 
 If you like it, please add a ⭐. If you don't like it, create a PR. 😆
 
@@ -133,6 +133,14 @@ model = Meta-Llama-3.1-70B-Instruct
 
 You can create a personal access token (PAT) [here](https://github.com/settings/tokens).
 The PAT does not require any permissions.
+
+If you use [Anthropic](https://www.anthropic.com):
+
+```ini
+[anthropic]
+provider = anthropic
+api_key = <your API key>
+```
 
 ### Install `fish-ai`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fish_ai"
-version = "0.13.6"
+version = "0.14.0"
 authors = [{ name = "Bastian Fredriksson", email = "realiserad@gmail.com" }]
 description = "Provides core functionality for fish-ai, an AI plugin for the fish shell."
 readme = "README.md"
@@ -23,6 +23,7 @@ dependencies = [
   "mistralai==1.0.2",
   "binaryornot==0.4.4",
   "azure-ai-inference==1.0.0b4",
+  "anthropic==0.34.2",
 ]
 
 [project.urls]


### PR DESCRIPTION
Add support for models hosted by [Anthropic](https://www.anthropic.com/), such as [Claude 3.5 Sonnet](https://www.anthropic.com/news/claude-3-5-sonnet).

To test this feature branch:

1. Sign up for an [Anthropic Console](https://console.anthropic.com/login) account and register an API key if you have not done so already. You need to top up your account with at least 5$ to use the API.

2. Remove any existing version of `fish-ai`:

```shell
fisher remove (fisher list fish-ai)
```

3. Check out the feature branch and install using `fisher`:

```shell
git checkout feature/anthropic-provider
fisher install .
```

4. Add the following to your `fish-ai.ini`:

```ini
[anthropic]
provider = anthropic
api_key = <paste API key here>
```

5. Switch to the Anthropic provider using `fish_ai_switch_context`.

I currently do not have API access. If you have tested this feature branch and it works for you, let me know and I'll merge it.