### PR TITLE
test: define a set of supported platforms

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,5 @@
 FROM albx79/what-bump:1.2.0 as what-bump
+FROM mikefarah/yq:4.44.3 as yq
 
 FROM mcr.microsoft.com/devcontainers/python:3.11-buster
 
@@ -7,3 +8,4 @@ COPY requirements-dev.txt .
 RUN pip3 install --break-system-packages -r requirements-dev.txt
 
 COPY --from=what-bump /what-bump /bin/what-bump
+COPY --from=yq /usr/bin/yq /bin/yq

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -7,14 +7,20 @@ on:
 jobs:
   python-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # https://devguide.python.org/versions
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     permissions:
       pull-requests: write
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up Python
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
+      with:
+          python-version: ${{ matrix.python-version }}
     - name: Install requirements
       run: |
         pip install -r .devcontainer/requirements-dev.txt

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -1,6 +1,6 @@
 name: Python tests
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches:
     - main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,13 @@ repos:
   rev: '7.1.1'
   hooks:
   - id: flake8
+- repo: local
+  hooks:
+  - id: supported-versions-check
+    name: Supported versions check
+    entry: ./ops/supported-versions-check.fish
+    language: script
+    pass_filenames: false
 - repo: https://github.com/compilerla/conventional-pre-commit
   rev: v3.4.0
   hooks:
@@ -52,3 +59,4 @@ ci:
   - fish_indent
   - fish_syntax
   - bump-version
+  - supported-versions-check

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 `fish-ai` adds AI functionality to [Fish](https://fishshell.com). It
 has been tested with macOS and Linux, but should run on any system where
-Python and git is installed.
+[a supported version of Python](https://github.com/Realiserad/fish-ai/blob/main/.github/workflows/python-tests.yaml)
+and git is installed.
 
 Originally based on [Tom Dörr's `fish.codex` repository](https://github.com/tom-doerr/codex.fish),
 but with some additional functionality.

--- a/functions/fish_ai_bug_report.fish
+++ b/functions/fish_ai_bug_report.fish
@@ -19,6 +19,9 @@ function fish_ai_bug_report
     print_header "Functionality tests"
     perform_functionality_tests
 
+    print_header "Compatibility check"
+    perform_compatibility_check
+
     if test "$error_found" = true
         echo "❌ Problems were found (see output above for details)."
         return 1
@@ -111,4 +114,17 @@ function perform_functionality_tests
         string shorten --max 50)
     set duration (math (date +%s) - $start)
     echo "explain 'date' -> '$result' (in $duration seconds)"
+    echo ""
+end
+
+function perform_compatibility_check
+    source ~/.config/fish/conf.d/fish_ai.fish
+    set python_version (~/.fish-ai/bin/python3 -c 'import platform; major, minor, _ = platform.python_version_tuple(); print(major, end="."); print(minor, end="")')
+    if ! contains $python_version $supported_versions
+        echo "🔔 This plugin has not been tested with Python $python_version and may not function correctly."
+        echo "The following versions are supported: $supported_versions"
+        set -g error_found true
+    else
+        echo "👍 Python $python_version is supported."
+    end
 end

--- a/ops/bump-version.fish
+++ b/ops/bump-version.fish
@@ -8,8 +8,12 @@ end
 
 git fetch --all >/dev/null
 set start_hash (git show-ref --hash refs/remotes/origin/main)
-set current_version (git show $start_hash:pyproject.toml | grep version | head -n 1 | cut -d'"' -f2)
-set next_version (what-bump --from $current_version $start_hash)
+set main_version (git show $start_hash:pyproject.toml | grep version | head -n 1 | cut -d'"' -f2)
+set current_version (cat pyproject.toml | grep version | head -n 1 | cut -d '"' -f2)
+set next_version (what-bump --from $main_version $start_hash)
+if test "$main_version" = "$next_version"
+    exit 0
+end
 if test "$current_version" = "$next_version"
     exit 0
 end

--- a/ops/supported-versions-check.fish
+++ b/ops/supported-versions-check.fish
@@ -1,0 +1,23 @@
+#!/usr/bin/env fish
+
+# Make sure the Python versions tested in the "Python tests" workflow
+# correspond to the compatibility check being performed during the
+# installation.
+
+if ! type -q yq
+    echo "❌ 'yq' is not installed."
+    echo "See https://github.com/mikefarah/yq/#install for installation instructions."
+    exit 1
+end
+
+set tested_versions (yq '.jobs.python-tests.strategy.matrix.python-version[]' \
+    .github/workflows/python-tests.yaml)
+
+source conf.d/fish_ai.fish
+
+if test "$tested_versions" != "$supported_versions"
+    echo "Supported versions: '$supported_versions'"
+    echo "Tested versions: '$tested_versions'"
+    echo "Update the 'supported_versions' variable in the 'conf.d/fish_ai.fish' file."
+    exit 1
+end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fish_ai"
-version = "0.10.0"
+version = "0.10.1"
 authors = [{ name = "Bastian Fredriksson", email = "realiserad@gmail.com" }]
 description = "Provides core functionality for fish-ai, an AI plugin for the fish shell."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Programming Language :: Python :: 3",
   "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
The plugin may break if the "wrong" version of Python is used as exemplified in #62. 

Run pytest on all supported versions specified [here](https://devguide.python.org/versions/) and warn during the installation if an untested version of Python is used.