### PR TITLE
feat: option to disable status emoji

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,5 +38,5 @@
     "mounts": [
         "source=${localEnv:HOME}/.config/fish-ai.ini,target=/home/vscode/.config/fish-ai.ini,type=bind,consistency=cached"
     ],
-    "postCreateCommand": "pre-commit install -t pre-commit -t commit-msg"
+    "postCreateCommand": "pre-commit install -t pre-commit -t commit-msg -t post-commit"
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,8 @@ repos:
     name: Bump version
     entry: ./ops/bump-version.fish
     language: script
-    stages: [commit-msg]
+    stages: [post-commit]
+    always_run: true
 ci:
   autofix_commit_msg: 'style: modified by hook'
   autoupdate_commit_msg: 'ci: pre-commit autoupdate'

--- a/README.md
+++ b/README.md
@@ -226,6 +226,19 @@ history_size = 5
 If you enable this option, consider the use of [`sponge`](https://github.com/meaningful-ooo/sponge)
 to automatically remove broken commands from your commandline history.
 
+### Disable the status emoji
+
+By default, a status emoji is shown in the [right prompt](https://fishshell.com/docs/current/cmds/fish_right_prompt.html).
+If you already use your right prompt for something else, or just don't like
+emojis, you can disable them:
+
+```ini
+[fish-ai]
+status_emoji = False
+```
+
+Restart any open terminal windows for the change to take effect.
+
 ## 🎭 Switch between contexts
 
 You can switch between different sections in the configuration using the

--- a/conf.d/fish_ai.fish
+++ b/conf.d/fish_ai.fish
@@ -14,8 +14,8 @@ bind \cP _fish_ai_codify_or_explain
 bind -k nul _fish_ai_autocomplete_or_fix
 
 ##
-## This section contains functionality for setting and clearing the status shown
-## in the right prompt.
+## This section contains functionality for clearing the status emoji
+## shown in the right prompt.
 ##
 bind \r 'clear_status; commandline -f execute'
 bind \cc 'clear_status; commandline -f repaint; commandline -f cancel-commandline'

--- a/functions/_fish_ai_autocomplete.fish
+++ b/functions/_fish_ai_autocomplete.fish
@@ -1,6 +1,10 @@
 #!/usr/bin/env fish
 
 function _fish_ai_autocomplete --description "Autocomplete the current command using AI." --argument-names command cursor_position
-    set selected_completion (~/.fish-ai/bin/autocomplete "$command" "$cursor_position" 2> /dev/null)
+    if test (~/.fish-ai/bin/lookup_setting "debug") = True
+        set selected_completion (~/.fish-ai/bin/autocomplete "$command" "$cursor_position")
+    else
+        set selected_completion (~/.fish-ai/bin/autocomplete "$command" "$cursor_position" 2> /dev/null)
+    end
     echo -n "$selected_completion"
 end

--- a/functions/_fish_ai_autocomplete_or_fix.fish
+++ b/functions/_fish_ai_autocomplete_or_fix.fish
@@ -1,7 +1,7 @@
 #!/usr/bin/env fish
 
-function fish_right_prompt
-    echo "$status_emoji"
+if test (~/.fish-ai/bin/lookup_setting status_emoji) != False
+    eval "function fish_right_prompt; echo (string escape \$status_emoji); end"
 end
 
 function _fish_ai_autocomplete_or_fix --description "Autocomplete the current command or fix the previous command using AI."

--- a/functions/_fish_ai_autocomplete_or_fix.fish
+++ b/functions/_fish_ai_autocomplete_or_fix.fish
@@ -1,10 +1,9 @@
 #!/usr/bin/env fish
 
-if test (~/.fish-ai/bin/lookup_setting status_emoji) != False
-    eval "function fish_right_prompt; echo (string escape \$status_emoji); end"
-end
-
 function _fish_ai_autocomplete_or_fix --description "Autocomplete the current command or fix the previous command using AI."
+    if test (~/.fish-ai/bin/lookup_setting status_emoji) != False
+        eval "function fish_right_prompt; echo (string escape \$status_emoji); end"
+    end
     set previous_status $status
     set input (commandline --current-buffer)
     if test -z "$input" && test $previous_status -ne 0

--- a/functions/_fish_ai_codify.fish
+++ b/functions/_fish_ai_codify.fish
@@ -1,6 +1,10 @@
 #!/usr/bin/env fish
 
 function _fish_ai_codify --description "Turn a comment into a command using AI." --argument-names comment
-    set output (~/.fish-ai/bin/codify "$comment" 2> /dev/null)
+    if test (~/.fish-ai/bin/lookup_setting "debug") = True
+        set output (~/.fish-ai/bin/codify "$comment")
+    else
+        set output (~/.fish-ai/bin/codify "$comment" 2> /dev/null)
+    end
     echo -n "$output"
 end

--- a/functions/_fish_ai_codify_or_explain.fish
+++ b/functions/_fish_ai_codify_or_explain.fish
@@ -1,10 +1,10 @@
 #!/usr/bin/env fish
 
-if test (~/.fish-ai/bin/lookup_setting status_emoji) != False
-    eval "function fish_right_prompt; echo (string escape \$status_emoji); end"
-end
-
 function _fish_ai_codify_or_explain --description "Transform a command into a comment and vice versa using AI."
+    if test (~/.fish-ai/bin/lookup_setting status_emoji) != False
+        eval "function fish_right_prompt; echo (string escape \$status_emoji); end"
+    end
+
     set input (commandline --current-buffer)
 
     if test -z "$input"

--- a/functions/_fish_ai_codify_or_explain.fish
+++ b/functions/_fish_ai_codify_or_explain.fish
@@ -1,7 +1,7 @@
 #!/usr/bin/env fish
 
-function fish_right_prompt
-    echo "$status_emoji"
+if test (~/.fish-ai/bin/lookup_setting status_emoji) != False
+    eval "function fish_right_prompt; echo (string escape \$status_emoji); end"
 end
 
 function _fish_ai_codify_or_explain --description "Transform a command into a comment and vice versa using AI."

--- a/functions/_fish_ai_explain.fish
+++ b/functions/_fish_ai_explain.fish
@@ -1,6 +1,10 @@
 #!/usr/bin/env fish
 
 function _fish_ai_explain --description "Turn a command into a comment using AI." --argument-names command
-    set output (~/.fish-ai/bin/explain "$command" 2> /dev/null)
+    if test (~/.fish-ai/bin/lookup_setting "debug") = True
+        set output (~/.fish-ai/bin/explain "$command")
+    else
+        set output (~/.fish-ai/bin/explain "$command" 2> /dev/null)
+    end
     echo -n "$output"
 end

--- a/functions/_fish_ai_fix.fish
+++ b/functions/_fish_ai_fix.fish
@@ -1,6 +1,10 @@
 #!/usr/bin/env fish
 
 function _fish_ai_fix --description "Fix a command using AI." --argument-names previous_command
-    set output (~/.fish-ai/bin/fix "$previous_command" 2> /dev/null)
+    if test (~/.fish-ai/bin/lookup_setting "debug") = True
+        set output (~/.fish-ai/bin/fix "$previous_command")
+    else
+        set output (~/.fish-ai/bin/fix "$previous_command" 2> /dev/null)
+    end
     echo -n "$output"
 end

--- a/functions/fish_ai_bug_report.fish
+++ b/functions/fish_ai_bug_report.fish
@@ -65,7 +65,7 @@ function print_dependencies
         return
     end
 
-    ~/.fish-ai/bin/python3 --version
+    echo "$(~/.fish-ai/bin/python3 --version) (the system default is $(python3 --version))"
     fish --version
     fisher --version
     git --version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fish_ai"
-version = "0.10.2"
+version = "0.11.0"
 authors = [{ name = "Bastian Fredriksson", email = "realiserad@gmail.com" }]
 description = "Provides core functionality for fish-ai, an AI plugin for the fish shell."
 readme = "README.md"
@@ -35,6 +35,7 @@ codify = "fish_ai.codify:codify"
 explain = "fish_ai.explain:explain"
 autocomplete = "fish_ai.autocomplete:autocomplete"
 switch_context = "fish_ai.switch_context:switch_context"
+lookup_setting = "fish_ai.config:lookup_setting"
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/src/fish_ai/config.py
+++ b/src/fish_ai/config.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from os import path
+import sys
+from configparser import ConfigParser
+
+config = ConfigParser()
+config.read(path.expanduser('~/.config/fish-ai.ini'))
+
+
+def lookup_setting():
+    print(get_config(sys.argv[1] or ''))
+
+
+def get_config(key):
+    if not config.has_section('fish-ai'):
+        # There is no configuration file or the user made a mistake.
+        # Just return 'None' here to simplify testing.
+        return None
+
+    active_section = config.get(section='fish-ai', option='configuration')
+
+    if config.has_option(section=active_section, option=key):
+        return config.get(section=active_section, option=key)
+
+    return config.get(section='fish-ai', option=key, fallback=None)

--- a/src/fish_ai/engine.py
+++ b/src/fish_ai/engine.py
@@ -4,8 +4,6 @@ from openai import OpenAI
 from openai import AzureOpenAI
 import google.generativeai as genai
 from google.generativeai.types import GenerationConfig
-from configparser import ConfigParser
-from os import path
 from os.path import isfile
 import platform
 import logging
@@ -21,9 +19,8 @@ from fish_ai.redact import redact
 import itertools
 from azure.ai.inference import ChatCompletionsClient
 from azure.core.credentials import AzureKeyCredential
-
-config = ConfigParser()
-config.read(path.expanduser('~/.config/fish-ai.ini'))
+from fish_ai.config import get_config
+from os import path
 
 
 def get_args():
@@ -125,20 +122,6 @@ def get_system_prompt():
         respond with a short message starting with "error: ".
         ''').format(os=get_os())
     }
-
-
-def get_config(key):
-    if not config.has_section('fish-ai'):
-        # There is no configuration file or the user made a mistake.
-        # Just return 'None' here to simplify testing.
-        return None
-
-    active_section = config.get(section='fish-ai', option='configuration')
-
-    if config.has_option(section=active_section, option=key):
-        return config.get(section=active_section, option=key)
-
-    return config.get(section='fish-ai', option=key, fallback=None)
 
 
 def get_openai_client():


### PR DESCRIPTION
As pointed out by @jjh2811 in #64 

> Currently, emojis are being displayed in the right-prompt of the fish shell. I have my custom right-prompt configuration, and I would appreciate it if there were an option to disable the emojis. I’ve been temporarily disabling the script that outputs the emojis for now, but I think it would be great if this feature were officially supported.

Add an option `status_emoji` which can be set to `False` to disable the status emoji in the right prompt.