### PR TITLE
feat: add cohere as a provider

### DIFF
--- a/.devcontainer/requirements-dev.txt
+++ b/.devcontainer/requirements-dev.txt
@@ -12,3 +12,4 @@ hugchat
 mistralai
 binaryornot
 anthropic
+cohere

--- a/README.md
+++ b/README.md
@@ -171,6 +171,14 @@ provider = anthropic
 api_key = <your API key>
 ```
 
+If you use [Cohere](https://cohere.com):
+
+```ini
+[cohere]
+provider = cohere
+api_key = <your API key>
+```
+
 ## 🙉 How to use
 
 ### Transform comments into commands and vice versa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fish_ai"
-version = "0.17.2"
+version = "0.18.0"
 authors = [{ name = "Bastian Fredriksson", email = "realiserad@gmail.com" }]
 description = "Provides core functionality for fish-ai, an AI plugin for the fish shell."
 readme = "README.md"
@@ -23,6 +23,7 @@ dependencies = [
   "mistralai==1.0.2",
   "binaryornot==0.4.4",
   "anthropic==0.42.0",
+  "cohere==5.13.4",
 ]
 
 [project.urls]

--- a/src/fish_ai/engine.py
+++ b/src/fish_ai/engine.py
@@ -23,6 +23,7 @@ from binaryornot.check import is_binary
 from os import access, R_OK
 from re import match
 from anthropic import Anthropic
+import cohere
 
 logger = logging.getLogger()
 
@@ -286,6 +287,16 @@ def get_response(messages):
             messages=user_messages
         )
         response = completions.content[0].text
+    elif get_config('provider') == 'cohere':
+        api_key = get_config('api_key')
+        client = cohere.ClientV2(api_key)
+        completions = client.chat(
+            model=get_config('model') or 'command-r-plus-08-2024',
+            messages=messages,
+            max_tokens=1024,
+            temperature=float(get_config('temperature') or '0.2'),
+        )
+        response = completions.message.content[0].text
     else:
         completions = get_openai_client().chat.completions.create(
             model=get_config('model') or 'gpt-4o',


### PR DESCRIPTION
This PR adds Cohere as a supported platform for fish-ai. I believe I covered all my bases here (adding a provider seems very plug and play), but please let me know if there are any changes I should make.