### PR TITLE
ci: fix broken pr workflows

### DIFF
--- a/.devcontainer/requirements-dev.txt
+++ b/.devcontainer/requirements-dev.txt
@@ -5,7 +5,6 @@ pyfakefs
 mutatest
 
 openai
-google-generativeai
 simple-term-menu
 iterfzf
 hugchat

--- a/.github/workflows/linkspector.yaml
+++ b/.github/workflows/linkspector.yaml
@@ -3,7 +3,8 @@ on:
   pull_request:
 jobs:
   check-links:
-    runs-on: ubuntu-latest
+    # TODO: Upgrade to ubuntu-latest when https://github.com/UmbrellaDocs/action-linkspector/issues/32 is resolved.
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         # https://devguide.python.org/versions
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -1,6 +1,6 @@
 name: Python tests
 on:
-  pull_request:
+  pull_request_target:
   push:
     branches:
     - main

--- a/README.md
+++ b/README.md
@@ -109,17 +109,6 @@ model = <your deployment name>
 api_key = <your API key>
 ```
 
-If you use [Gemini](https://ai.google.dev):
-
-```ini
-[fish-ai]
-configuration = gemini
-
-[gemini]
-provider = google
-api_key = <your API key>
-```
-
 If you use [Hugging Face](https://huggingface.co):
 
 ```ini

--- a/conf.d/fish_ai.fish
+++ b/conf.d/fish_ai.fish
@@ -2,7 +2,7 @@
 ## Supported major.minor versions of Python.
 ## Unit tests are run in CI against these versions.
 ##
-set -g supported_versions 3.9 3.10 3.11 3.12
+set -g supported_versions 3.9 3.10 3.11 3.12 3.13
 
 ##
 ## This section contains the keybindings for fish-ai. If you want to change the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fish_ai"
-version = "0.18.0"
+version = "1.0.0"
 authors = [{ name = "Bastian Fredriksson", email = "realiserad@gmail.com" }]
 description = "Provides core functionality for fish-ai, an AI plugin for the fish shell."
 readme = "README.md"
@@ -16,7 +16,6 @@ classifiers = [
 ]
 dependencies = [
   "openai==1.58.1",
-  "google-generativeai==0.8.3",
   "simple-term-menu==1.6.6",
   "iterfzf==1.4.0.54.3",
   "hugchat==0.4.17",


### PR DESCRIPTION
Some workflows triggered by a PR are not working properly.

- Make sure Linkspector runs on Ubuntu 22.04. The new runner provided by GitHub based on Ubuntu 24.04 is not yet compatible with the latest Linkspector action.
- Add support for Python 3.13 to make the installation tests on latest Fedora and Arch Linux pass.
- Revisit the workflow for reporting code coverage. See [this issue in the `orgoro/coverage` repository](https://github.com/orgoro/coverage/issues/259) for details.