### PR TITLE
feat: add support for DeepSeek provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,15 @@ provider = cohere
 api_key = <your API key>
 ```
 
+If you use [DeepSeek](https://www.deepseek.com):
+
+```ini
+[deepseek]
+provider = deepseek
+api_key = <your API key>
+model = deepseek-chat
+```
+
 ## 🙉 How to use
 
 ### Transform comments into commands and vice versa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fish_ai"
-version = "1.0.3"
+version = "1.1.0"
 authors = [{ name = "Bastian Fredriksson", email = "realiserad@gmail.com" }]
 description = "Provides core functionality for fish-ai, an AI plugin for the fish shell."
 readme = "README.md"

--- a/src/fish_ai/engine.py
+++ b/src/fish_ai/engine.py
@@ -168,6 +168,12 @@ def get_openai_client():
             api_key=get_config('api_key'),
             organization=get_config('organization'),
         )
+    elif (get_config('provider') == 'deepseek'):
+        # DeepSeek is compatiable with OpenAI Python SDK
+        return OpenAI(
+            api_key=get_config('api_key'),
+            base_url='https://api.deepseek.com'
+        )
     else:
         raise Exception('Unknown provider "{}".'
                         .format(get_config('provider')))

--- a/src/fish_ai/engine.py
+++ b/src/fish_ai/engine.py
@@ -169,7 +169,7 @@ def get_openai_client():
             organization=get_config('organization'),
         )
     elif (get_config('provider') == 'deepseek'):
-        # DeepSeek is compatiable with OpenAI Python SDK
+        # DeepSeek is compatible with OpenAI Python SDK
         return OpenAI(
             api_key=get_config('api_key'),
             base_url='https://api.deepseek.com'


### PR DESCRIPTION
This PR adds DeepSeek support for fish-ai with minimal changes, as the DeepSeek API supports the OpenAI SDK with just a change to the `base_url` parameter.