### PR TITLE
fix: specify max_tokens parameter for anthropic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fish_ai"
-version = "1.2.0"
+version = "1.2.1"
 authors = [{ name = "Bastian Fredriksson", email = "realiserad@gmail.com" }]
 description = "Provides core functionality for fish-ai, an AI plugin for the fish shell."
 readme = "README.md"

--- a/src/fish_ai/engine.py
+++ b/src/fish_ai/engine.py
@@ -238,10 +238,11 @@ def get_response(messages):
         )
         system_messages, user_messages = get_messages_for_anthropic(messages)
         completions = client.messages.create(
-            model=get_config('model') or 'claude-3-5-sonnet-20241022',
+            model=get_config('model') or 'claude-3-7-sonnet-latest',
             temperature=float(get_config('temperature') or '0.2'),
             system='\n'.join(system_messages),
-            messages=user_messages
+            messages=user_messages,
+            max_tokens=4096
         )
         response = completions.content[0].text
     elif get_config('provider') == 'cohere':


### PR DESCRIPTION
The Anthropic API requires the `max_tokens` parameter to be set. It was removed for all providers as a part of [commit `891a1a0`](https://github.com/Realiserad/fish-ai/commit/891a1a0fc37c812e358524bb17b0e5e3acf1e1dc).

The [Anthropic documentation](https://docs.anthropic.com/en/api/messages#body-max-tokens) says:

> The maximum number of tokens to generate before stopping.
>
> Note that our models may stop before reaching this maximum. This parameter only specifies the > absolute maximum number of tokens to generate.
>
> Different models have different maximum values for this parameter.  See [models](https://docs.anthropic.com/en/docs/models-overview) for details.

`4096` is the highest value that will work with all models, and should be enough for our usecase, so let's use that.

It also looks like we are specifying an old Anthropic model by default. Point to the latest model.

See issue #180 for a bug report.