### PR TITLE
Add support for saving api_key to secure credential storage 

### DIFF
--- a/.devcontainer/requirements-dev.txt
+++ b/.devcontainer/requirements-dev.txt
@@ -12,3 +12,4 @@ mistralai
 binaryornot
 anthropic
 cohere
+keyring

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ configuration = huggingface
 [huggingface]
 provider = huggingface
 email = <your email>
-password = <your password>
+api_key = <your password>
 model = meta-llama/Llama-3.3-70B-Instruct
 ```
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ api_key = <your API key>
 model = deepseek-chat
 ```
 
+### Put the API key on your keyring
+
+Instead of putting the API key in the configuration file, you can let
+`fish-ai` load it from your keyring. To save a new API key or transfer
+an existing API key to your keyring, run `fish_ai put_api_key`.
+
 ## 🙉 How to use
 
 ### Transform comments into commands and vice versa

--- a/conf.d/fish_ai.fish
+++ b/conf.d/fish_ai.fish
@@ -94,6 +94,7 @@ function _fish_ai_update --on-event fish_ai_update
     end
     python_version_check
     symlink_truststore
+    warn_plaintext_api_keys
 end
 
 function _fish_ai_uninstall --on-event fish_ai_uninstall
@@ -158,6 +159,20 @@ function symlink_truststore --description "Use the bundle with CA certificates t
     else if test -f /etc/ssl/cert.pem
         echo "🔑 Symlinking to certificates stored in /etc/ssl/cert.pem."
         ln -snf /etc/ssl/cert.pem (~/.fish-ai/bin/python3 -c 'import certifi; print(certifi.where())')
+    end
+end
+
+function warn_plaintext_api_keys --description "Warn about plaintext API keys."
+    if grep -q "^api_key" ~/.config/fish-ai.ini
+        echo -n "🚨 One or more plaintext API keys are stored in "
+        set_color --bold red
+        echo -n "~/.config/fish-ai.ini"
+        set_color normal
+        echo -n ". Consider moving them to your keyring using "
+        set_color --italics blue
+        echo -n fish_ai_put_api_key
+        set_color normal
+        echo "."
     end
 end
 

--- a/functions/fish_ai_put_api_key.fish
+++ b/functions/fish_ai_put_api_key.fish
@@ -1,0 +1,5 @@
+#!/usr/bin/env fish
+
+function fish_ai_put_api_key --description "Put an API key on the user's keyring."
+    ~/.fish-ai/bin/put_api_key
+end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fish_ai"
-version = "1.4.2"
+version = "1.5.0"
 authors = [{ name = "Bastian Fredriksson", email = "realiserad@gmail.com" }]
 description = "Provides core functionality for fish-ai, an AI plugin for the fish shell."
 readme = "README.md"
@@ -23,6 +23,7 @@ dependencies = [
   "binaryornot==0.4.4",
   "anthropic==0.49.0",
   "cohere==5.14.0",
+  "keyring==25.6.0",
 ]
 
 [project.urls]
@@ -35,6 +36,7 @@ codify = "fish_ai.codify:codify"
 explain = "fish_ai.explain:explain"
 autocomplete = "fish_ai.autocomplete:autocomplete"
 switch_context = "fish_ai.switch_context:switch_context"
+put_api_key = "fish_ai.put_api_key:put_api_key"
 lookup_setting = "fish_ai.config:lookup_setting"
 refine = "fish_ai.autocomplete:refine_completions"
 

--- a/src/fish_ai/config.py
+++ b/src/fish_ai/config.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 from os import path
 import sys
 from configparser import ConfigParser
@@ -24,5 +25,10 @@ def get_config(key):
 
     if config.has_option(section='fish-ai', option=key):
         return path.expandvars(config.get(section='fish-ai', option=key))
+
+    if key == 'api_key' or key == 'password':
+        # If not specified in the configuration, try to load from keyring
+        import keyring
+        return keyring.get_password('fish-ai', active_section)
 
     return None

--- a/src/fish_ai/engine.py
+++ b/src/fish_ai/engine.py
@@ -208,7 +208,7 @@ def get_response(messages):
         from hugchat.login import Login
 
         email = get_config('email')
-        password = get_config('password')
+        password = get_config('api_key') or get_config('password')
         cookies = Login(email, password).login(
             cookie_dir_path=expanduser('~/.fish-ai/cookies/'),
             save_cookies=True)

--- a/src/fish_ai/put_api_key.py
+++ b/src/fish_ai/put_api_key.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+from simple_term_menu import TerminalMenu
+from configparser import ConfigParser
+from os import path
+import sys
+import keyring
+
+
+def select_section(config, sections):
+    if len(sections) == 1:
+        return sections[0]
+    else:
+        options = [
+            '{} (provided by {})'.format(section, config.get(
+                section=section,
+                option='provider'))
+            for section in sections]
+        terminal_menu = TerminalMenu(options)
+        terminal_menu.title = 'Select context'
+        index = terminal_menu.show()
+        if index is None:
+            return
+        return options[index].split(' ')[0]
+
+
+def put_api_key():
+    config = ConfigParser()
+    config.read(path.expanduser('~/.config/fish-ai.ini'))
+    sections = config.sections()
+    sections.remove('fish-ai')
+    selected_section = select_section(config, sections)
+
+    if config.has_option(section=selected_section, option='api_key'):
+        # Move API key from the configuration to the keyring
+        api_key = config.get(section=selected_section, option='api_key')
+        keyring.set_password('fish-ai', selected_section, api_key)
+        config.remove_option(selected_section, 'api_key')
+        config.write(open(path.expanduser('~/.config/fish-ai.ini'), 'w'))
+    else:
+        # Ask for the API key and put it on the keyring
+        p = (f'Provide an API key for \033[92m{selected_section}\033[0m.\n'
+             '🔑 ')
+        print(p, end='')
+        sys.stdout.flush()
+        api_key = sys.stdin.readline().strip()
+        keyring.set_password('fish-ai', selected_section, api_key)
+
+    print((f'🔒 The API key for \033[92m{selected_section}\033[0m is now on '
+           'your keyring.'))


### PR DESCRIPTION
If the user sets the setting use_keyring = 1 under [fish-ai] section in the config file, the tool will retrieve the api_key from secure credential storage such as KDE Wallet, Mac Keyring, Freedesktop Secure Storage or Windows Credential Manager.

If the api_key is not in the secure storage, the tool will upon first use ask for the user to input the api_key and will save it in the credential storage for later use.