### PR TITLE
feat: comply with the xdg base directory specification

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -36,10 +36,10 @@ The install hook will then create a virtual environment using `uv`or `venv`
 and run `pip` to install the `fish_ai` module directly from the git repository
 here on GitHub.
 
-The virtual environment is created in the `~/.fish-ai` directory. It will
-contain the `fish_ai` module along with its dependencies.
+The virtual environment is created in the `$XDG_DATA_HOME/fish-ai` directory. It
+contains the `fish_ai` module along with its dependencies.
 
-The configuration file `~/.config/fish-ai.ini` is the only file that lives
+The configuration file `$XDG_CONFIG_HOME/fish-ai.ini` is the only file that lives
 outside this virtual environment, so the user can remove the plugin without
 their configuration disappearing.
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ fisher install realiserad/fish-ai
 
 ### Create a configuration
 
-Create a configuration file `~/.config/fish-ai.ini` where you specify which LLM
-`fish-ai` should talk to. If you're not sure, use GitHub Models.
+Create a configuration file `$XDG_CONFIG_HOME/fish-ai.ini` (use
+`~/.config/fish-ai.ini` if `$XDG_CONFIG_HOME` is not set) where
+you specify which LLM `fish-ai` should talk to. If you're not sure,
+use GitHub Models.
 
 #### GitHub Models
 
@@ -419,7 +421,7 @@ logging to file using `log = <path to file>`, for example:
 ```ini
 [fish-ai]
 debug = True
-log = ~/.fish-ai/log.txt
+log = /tmp/fish-ai.log
 ```
 
 ### Run the tests

--- a/functions/_fish_ai_autocomplete.fish
+++ b/functions/_fish_ai_autocomplete.fish
@@ -1,10 +1,12 @@
 #!/usr/bin/env fish
 
+set install_dir "$(get_install_dir)"
+
 function _fish_ai_autocomplete --description "Autocomplete the current command using AI." --argument-names command cursor_position
-    if test (~/.fish-ai/bin/lookup_setting "debug") = True
-        set selected_completion (~/.fish-ai/bin/autocomplete "$command" "$cursor_position")
+    if test ("$install_dir/bin/lookup_setting" "debug") = True
+        set selected_completion ("$install_dir/bin/autocomplete" "$command" "$cursor_position")
     else
-        set selected_completion (~/.fish-ai/bin/autocomplete "$command" "$cursor_position" 2> /dev/null)
+        set selected_completion ("$install_dir/bin/autocomplete" "$command" "$cursor_position" 2> /dev/null)
     end
     echo -n "$selected_completion"
 end

--- a/functions/_fish_ai_codify.fish
+++ b/functions/_fish_ai_codify.fish
@@ -1,10 +1,12 @@
 #!/usr/bin/env fish
 
+set install_dir "$(get_install_dir)"
+
 function _fish_ai_codify --description "Turn a comment into a command using AI." --argument-names comment
-    if test (~/.fish-ai/bin/lookup_setting "debug") = True
-        set output (~/.fish-ai/bin/codify "$comment")
+    if test ("$install_dir/bin/lookup_setting" "debug") = True
+        set output ("$install_dir/bin/codify" "$comment")
     else
-        set output (~/.fish-ai/bin/codify "$comment" 2> /dev/null)
+        set output ("$install_dir/bin/codify" "$comment" 2> /dev/null)
     end
     echo -n "$output"
 end

--- a/functions/_fish_ai_explain.fish
+++ b/functions/_fish_ai_explain.fish
@@ -1,10 +1,12 @@
 #!/usr/bin/env fish
 
+set install_dir "$(get_install_dir)"
+
 function _fish_ai_explain --description "Turn a command into a comment using AI." --argument-names command
-    if test (~/.fish-ai/bin/lookup_setting "debug") = True
-        set output (~/.fish-ai/bin/explain "$command")
+    if test ("$install_dir/bin/lookup_setting" "debug") = True
+        set output ("$install_dir/bin/explain" "$command")
     else
-        set output (~/.fish-ai/bin/explain "$command" 2> /dev/null)
+        set output ("$install_dir/bin/explain" "$command" 2> /dev/null)
     end
     echo -n "$output"
 end

--- a/functions/_fish_ai_fix.fish
+++ b/functions/_fish_ai_fix.fish
@@ -1,10 +1,12 @@
 #!/usr/bin/env fish
 
+set install_dir "$(get_install_dir)"
+
 function _fish_ai_fix --description "Fix a command using AI." --argument-names previous_command
-    if test (~/.fish-ai/bin/lookup_setting "debug") = True
-        set output (~/.fish-ai/bin/fix "$previous_command")
+    if test ("$install_dir/bin/lookup_setting" "debug") = True
+        set output ("$install_dir/bin/fix" "$previous_command")
     else
-        set output (~/.fish-ai/bin/fix "$previous_command" 2> /dev/null)
+        set output ("$install_dir/bin/fix" "$previous_command" 2> /dev/null)
     end
     echo -n "$output"
 end

--- a/functions/fish_ai_put_api_key.fish
+++ b/functions/fish_ai_put_api_key.fish
@@ -1,5 +1,6 @@
 #!/usr/bin/env fish
 
+set install_dir "$(get_install_dir)"
 function fish_ai_put_api_key --description "Put an API key on the user's keyring."
-    ~/.fish-ai/bin/put_api_key
+    "$install_dir/bin/put_api_key"
 end

--- a/functions/fish_ai_switch_context.fish
+++ b/functions/fish_ai_switch_context.fish
@@ -1,5 +1,7 @@
 #!/usr/bin/env fish
 
+set install_dir "$(get_install_dir)"
+
 function fish_ai_switch_context --description "Interactively switch to a different context."
-    ~/.fish-ai/bin/switch_context
+    "$install_dir/bin/switch_context"
 end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fish_ai"
-version = "1.8.0"
+version = "1.9.0"
 authors = [{ name = "Bastian Fredriksson", email = "realiserad@gmail.com" }]
 description = "Provides core functionality for fish-ai, an AI plugin for the fish shell."
 readme = "README.md"

--- a/src/fish_ai/autocomplete.py
+++ b/src/fish_ai/autocomplete.py
@@ -178,9 +178,10 @@ def yield_completions(commandline,
 
 
 def get_reload_command(commandline, cursor_position):
-    return ('reload(~/.fish-ai/bin/refine {commandline} '
+    return ('reload({install_dir}/bin/refine {commandline} '
             '{cursor_position} {completions_count} '
             '{instructions})+clear-query').format(
+                install_dir=engine.get_install_dir(),
                 # b64 encode commandline buffer to deal with single quotes
                 commandline=b64encode(commandline.encode()).decode(),
                 cursor_position=cursor_position,

--- a/src/fish_ai/config.py
+++ b/src/fish_ai/config.py
@@ -3,9 +3,14 @@
 from os import path
 import sys
 from configparser import ConfigParser
+import os
 
-config = ConfigParser()
-config.read(path.expanduser('~/.config/fish-ai.ini'))
+
+def get_config_path():
+    if 'XDG_CONFIG_HOME' in os.environ:
+        return path.expandvars('$XDG_CONFIG_HOME/fish-ai.ini')
+    else:
+        return path.expanduser('~/.config/fish-ai.ini')
 
 
 def lookup_setting():
@@ -32,3 +37,7 @@ def get_config(key):
         return keyring.get_password('fish-ai', active_section)
 
     return None
+
+
+config = ConfigParser()
+config.read(get_config_path())

--- a/src/fish_ai/engine.py
+++ b/src/fish_ai/engine.py
@@ -2,11 +2,11 @@
 
 import logging
 from logging.handlers import SysLogHandler, RotatingFileHandler
-from os.path import isfile, exists, expanduser
+from os.path import isfile, exists, expanduser, expandvars
 from platform import system, mac_ver
 from time import time_ns
 import textwrap
-from os import access, R_OK
+from os import access, R_OK, environ
 from re import match
 from binaryornot.check import is_binary
 from subprocess import run, PIPE, DEVNULL, Popen
@@ -245,8 +245,10 @@ def get_response(messages):
 
         email = get_config('email')
         password = get_config('api_key') or get_config('password')
+        # TODO: Use XDG_CACHE_DIR
         cookies = Login(email, password).login(
-            cookie_dir_path=expanduser('~/.fish-ai/cookies/'),
+            cookie_dir_path='{install_dir}/cookies'.format(
+                install_dir=get_install_dir()),
             save_cookies=True)
 
         bot = hugchat.ChatBot(
@@ -355,3 +357,10 @@ def get_response(messages):
     get_logger().debug('Processing time: ' +
                        str(round((end_time - start_time) / 1000000)) + ' ms.')
     return response
+
+
+def get_install_dir():
+    if 'XDG_DATA_HOME' in environ:
+        return expandvars('$XDG_DATA_HOME/fish-ai')
+    else:
+        return expanduser('~/.local/share/fish-ai')

--- a/src/fish_ai/put_api_key.py
+++ b/src/fish_ai/put_api_key.py
@@ -2,9 +2,9 @@
 
 from simple_term_menu import TerminalMenu
 from configparser import ConfigParser
-from os import path
 import sys
 import keyring
+from fish_ai import config
 
 
 def select_section(config, sections):
@@ -25,18 +25,20 @@ def select_section(config, sections):
 
 
 def put_api_key():
-    config = ConfigParser()
-    config.read(path.expanduser('~/.config/fish-ai.ini'))
-    sections = config.sections()
+    configuration_file = ConfigParser()
+    configuration_file.read(config.get_config_path())
+    sections = configuration_file.sections()
     sections.remove('fish-ai')
-    selected_section = select_section(config, sections)
+    selected_section = select_section(configuration_file, sections)
 
-    if config.has_option(section=selected_section, option='api_key'):
+    if configuration_file.has_option(section=selected_section,
+                                     option='api_key'):
         # Move API key from the configuration to the keyring
-        api_key = config.get(section=selected_section, option='api_key')
+        api_key = configuration_file.get(section=selected_section,
+                                         option='api_key')
         keyring.set_password('fish-ai', selected_section, api_key)
-        config.remove_option(selected_section, 'api_key')
-        config.write(open(path.expanduser('~/.config/fish-ai.ini'), 'w'))
+        configuration_file.remove_option(selected_section, 'api_key')
+        configuration_file.write(open(config.get_config_path(), 'w'))
     else:
         # Ask for the API key and put it on the keyring
         p = (f'Provide an API key for \033[92m{selected_section}\033[0m.\n'

--- a/src/fish_ai/switch_context.py
+++ b/src/fish_ai/switch_context.py
@@ -3,11 +3,12 @@
 from simple_term_menu import TerminalMenu
 from configparser import ConfigParser
 from os import path
+from fish_ai import engine
 
 
 def switch_context():
     config = ConfigParser()
-    config.read(path.expanduser('~/.config/fish-ai.ini'))
+    config.read(path.expanduser(engine.get_install_dir()))
     sections = config.sections()
     sections.remove('fish-ai')
     options = [
@@ -22,5 +23,5 @@ def switch_context():
         return
     active_section = options[index].split(' ')[0]
     config.set(section='fish-ai', option='configuration', value=active_section)
-    config.write(open(path.expanduser('~/.config/fish-ai.ini'), 'w'))
+    config.write(open(path.expanduser(engine.get_install_dir()), 'w'))
     print("💪 Now using '{}'.".format(active_section))


### PR DESCRIPTION
Do not clutter the user's home directory if XDG environment variables are set.

Put Python virtual environment in `$XDG_DATA_HOME` instead of `$HOME` and the configuration file in `$XDG_CONFIG_HOME` instead of `$HOME/.config`.

Closes: #295