### PR TITLE
Update groq

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fish_ai"
-version = "1.9.2"
+version = "1.9.3"
 authors = [{ name = "Bastian Fredriksson", email = "realiserad@gmail.com" }]
 description = "Provides core functionality for fish-ai, an AI plugin for the fish shell."
 readme = "README.md"

--- a/src/fish_ai/engine.py
+++ b/src/fish_ai/engine.py
@@ -309,7 +309,9 @@ def get_response(messages):
         completions = client.chat(**params)
         response = completions.message.content[0].text
     elif get_config('provider') == 'groq':
-        model = get_config('model') or 'qwen-qwq-32b'
+        default_groq_model = 'qwen/qwen3-32b'
+        groq_qwen_reasoning_models = ['qwen/qwen3-32b', 'qwen-qwq-32b']
+        model = get_config('model') or default_groq_model
         params = {
             'model': model,
             'messages': messages,
@@ -322,7 +324,7 @@ def get_response(messages):
         if temp != 'None':
             params['temperature'] = float(temp or '0.6')
         # This removes the thinking tokens for the qwen-qwq-32b model:
-        if model == 'qwen-qwq-32b':
+        if model in groq_qwen_reasoning_models:
             params['reasoning_format'] = 'parsed'
         completions = get_openai_client().chat.completions.create(**params)
         response = completions.choices[0].message.content


### PR DESCRIPTION
Received a GroqCloud Deprecation Notice for qwen-qwq-32b.

This update extends support for the newer qwen/qwen3-32b and makes it the default one if model not specified in config.

