### PR TITLE
feat: make progress indicator configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,19 @@ unterminated parenthesis before the cursor. For example, if you autocomplete
 This behaviour is disabled by default, as it may slow down the completion
 process and lead to commands being executed twice.
 
+### Configure the progress indicator
+
+You can change the progress indicator (the default is ⏳) shown when the
+plugin is waiting for a response from the LLM.
+
+To change the default, set the `progress_indicator` option to zero or
+more characters.
+
+```ini
+[fish-ai]
+progress_indicator = wait...
+```
+
 ## 🎭 Switch between contexts
 
 You can switch between different sections in the configuration using the

--- a/conf.d/fish_ai.fish
+++ b/conf.d/fish_ai.fish
@@ -223,9 +223,12 @@ function _fish_ai_show_progress_indicator --description "Show a progress indicat
     else
         set rplen 0
     end
+    # Get the progress indicator from the configuration, use hourglass emoji if not set
+    set progress_indicator ("$install_dir/bin/lookup_setting" progress_indicator '⏳')
+    set pilen (string length "$progress_indicator")
     # Move the cursor to the end of the line and insert progress indicator
-    tput hpa (math $COLUMNS - $rplen - 2)
-    echo -n '⏳'
+    tput hpa (math $COLUMNS - $rplen - 1 - $pilen)
+    echo -n "$progress_indicator"
 end
 
 function _fish_ai_notify_custom_keybindings --description "Print a message when custom keybindings are used."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fish_ai"
-version = "1.9.3"
+version = "1.10.0"
 authors = [{ name = "Bastian Fredriksson", email = "realiserad@gmail.com" }]
 description = "Provides core functionality for fish-ai, an AI plugin for the fish shell."
 readme = "README.md"
@@ -41,6 +41,7 @@ switch_context = "fish_ai.switch_context:switch_context"
 put_api_key = "fish_ai.put_api_key:put_api_key"
 lookup_setting = "fish_ai.config:lookup_setting"
 refine = "fish_ai.autocomplete:refine_completions"
+get_progress_indicator = "fish_ai.get_progress_indicator:get_progress_indicator"
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/src/fish_ai/config.py
+++ b/src/fish_ai/config.py
@@ -14,7 +14,13 @@ def get_config_path():
 
 
 def lookup_setting():
-    print(get_config(sys.argv[1] or ''))
+    value = get_config(sys.argv[1] or '')
+    if value is not None:
+        print(value)
+    elif len(sys.argv) > 2:
+        print(sys.argv[2])
+    else:
+        print('')
 
 
 def get_config(key):


### PR DESCRIPTION
Make the progress indicator (default is the ⏳ emoji), shown when the plugin is waiting for a response from the LLM, configurable in `fish-ai.ini`.

Closes: #303