### PR TITLE
feat!: remove huggingface provider

### DIFF
--- a/.devcontainer/requirements-dev.txt
+++ b/.devcontainer/requirements-dev.txt
@@ -7,7 +7,6 @@ mutatest
 openai
 simple-term-menu
 iterfzf
-hugchat
 mistralai
 binaryornot
 anthropic

--- a/README.md
+++ b/README.md
@@ -155,24 +155,6 @@ model = <your deployment name>
 api_key = <your API key>
 ```
 
-#### Hugging Face
-
-To use [Hugging Face](https://huggingface.co):
-
-```ini
-[fish-ai]
-configuration = huggingface
-
-[huggingface]
-provider = huggingface
-email = <your email>
-api_key = <your password>
-model = meta-llama/Llama-3.3-70B-Instruct
-```
-
-Available models are listed [here](https://huggingface.co/chat/models).
-Note that 2FA must be disabled on the account.
-
 #### Mistral
 
 To use [Mistral](https://mistral.ai):
@@ -299,8 +281,6 @@ Here is an example of how to increase the temperature to `0.5`.
 [fish-ai]
 temperature = 0.5
 ```
-
-This option is not supported when using the `huggingface` provider.
 
 Some reasoning models, such as OpenAI's o3, does not support the
 temperature parameter, and you need to explicitly disable it by

--- a/conf.d/fish_ai.fish
+++ b/conf.d/fish_ai.fish
@@ -85,6 +85,11 @@ function _fish_ai_update --on-event fish_ai_update
         echo "👷 Moving configuration file to '$config_path'."
         mv -u "$HOME/.config/fish-ai.ini" "$config_path"
     end
+    # Upgrade to fish-ai 2.0.0
+    set provider ("$install_dir/bin/lookup_setting" provider)
+    if test "$provider" = huggingface
+        echo "🌇 The provider for Hugging Face has been removed. Switch to a different provider."
+    end
 
     _fish_ai_set_python_version
     if type -q uv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fish_ai"
-version = "1.10.0"
+version = "2.0.0"
 authors = [{ name = "Bastian Fredriksson", email = "realiserad@gmail.com" }]
 description = "Provides core functionality for fish-ai, an AI plugin for the fish shell."
 readme = "README.md"
@@ -21,7 +21,6 @@ dependencies = [
   "mistralai==1.7.0",
   "binaryornot==0.4.4",
   "anthropic==0.57.1",
-  "hugchat==0.5.1",
   "cohere==5.16.1",
   "keyring==25.6.0",
   "groq==0.29.0",

--- a/src/fish_ai/engine.py
+++ b/src/fish_ai/engine.py
@@ -239,28 +239,7 @@ def get_response(messages):
 
     start_time = time_ns()
 
-    if get_config('provider') == 'huggingface':
-        from hugchat import hugchat
-        from hugchat.login import Login
-
-        email = get_config('email')
-        password = get_config('api_key') or get_config('password')
-        # TODO: Use XDG_CACHE_DIR
-        cookies = Login(email, password).login(
-            cookie_dir_path='{install_dir}/cookies'.format(
-                install_dir=get_install_dir()),
-            save_cookies=True)
-
-        bot = hugchat.ChatBot(
-            cookies=cookies.get_dict(),
-            system_prompt=create_system_prompt(messages),
-            default_llm=get_config('model') or
-            'meta-llama/Llama-3.3-70B-Instruct')
-
-        response = bot.chat(
-            messages[-1].get('content')).wait_until_done()
-        bot.delete_conversation(bot.get_conversation_info())
-    elif get_config('provider') == 'mistral':
+    if get_config('provider') == 'mistral':
         from mistralai import Mistral
 
         client = Mistral(


### PR DESCRIPTION
The chat UI hosted by Hugging Face has been shut down and thus the `huggingface` provider is no longer
functional.

Closes: #311
BREAKING CHANGE: The `huggingface` provider is no longer supported. Migrate to a different provider.