### PR TITLE
fix: use fish key names for binds after fish 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,18 +278,18 @@ For example, if you have the following output from `fish_key_reader`:
 ```shell
 $ fish_key_reader
 Press a key:
-bind \cP 'do something'
+bind ctrl-p 'do something'
 $ fish_key_reader
 Press a key:
-bind -k nul 'do something'
+bind ctrl-space 'do something'
 ```
 
 Then put the following in your configuration file:
 
 ```ini
 [fish-ai]
-keymap_1 = \cP
-keymap_2 = '-k nul'
+keymap_1 = 'ctrl-p'
+keymap_2 = 'ctrl-space'
 ```
 
 Restart the shell for the changes to take effect.

--- a/conf.d/fish_ai.fish
+++ b/conf.d/fish_ai.fish
@@ -15,17 +15,21 @@ function _fish_ai_bind --description "Create keybindings for fish-ai."
     if test -n ("$_fish_ai_install_dir/bin/lookup_setting" keymap_1)
         "$_fish_ai_install_dir/bin/lookup_setting" keymap_1 | string unescape | read -g -a _fish_ai_keymap_1
     else
-        set -g _fish_ai_keymap_1 \cp
+        # prefer fish key names above fish 4.x
+        if string match -r '^[0-3]\.' "$FISH_VERSION" &>/dev/null
+            set -g _fish_ai_keymap_1 \cp
+        else
+            set -g _fish_ai_keymap_1 ctrl-p
+        end
     end
     if test -n ("$_fish_ai_install_dir/bin/lookup_setting" keymap_2)
         "$_fish_ai_install_dir/bin/lookup_setting" keymap_2 | string unescape | read -g -a _fish_ai_keymap_2
     else
-        if type -q sw_vers
-            # macOS
-            set -g _fish_ai_keymap_2 ctrl-space
-        else
-            # Linux
+        # prefer fish key names above fish 4.x
+        if string match -r '^[0-3]\.' "$FISH_VERSION" &>/dev/null
             set -g _fish_ai_keymap_2 -k nul
+        else
+            set -g _fish_ai_keymap_2 ctrl-space
         end
     end
     if test "$fish_key_bindings" = fish_vi_key_bindings

--- a/functions/fish_ai_bug_report.fish
+++ b/functions/fish_ai_bug_report.fish
@@ -54,7 +54,7 @@ function print_environment
 end
 
 function print_key_bindings
-    bind --key | grep --color=never _fish_ai
+    bind | grep --color=never _fish_ai
     echo ""
     echo "Key bindings in use: $fish_key_bindings"
     echo ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fish_ai"
-version = "2.3.0"
+version = "2.3.1"
 authors = [{ name = "Bastian Fredriksson", email = "realiserad@gmail.com" }]
 description = "Provides core functionality for fish-ai, an AI plugin for the fish shell."
 readme = "README.md"


### PR DESCRIPTION
Fish 4.1.0 removes the deprecated -k flag, we should use fish key names instead

`bind` still supports binds like \cp, but ctrl-p style is preferred (and is what is returned from fish_key_reader) user overrides in the ini should still work, unless they use `-k`. but in that case they'll still get a warning and should update their config.

I've updated the docs to reflect this, and added a fallback for fish <4.x

Also removed the macos/linux check, fish key names work in either case on 4.x and don't work on 3.x

Fixes #393 