### PR TITLE
feat(python): add support for python 3.14

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         # https://devguide.python.org/versions
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     permissions:
       pull-requests: write
     steps:

--- a/conf.d/fish_ai.fish
+++ b/conf.d/fish_ai.fish
@@ -2,8 +2,7 @@
 ## Supported major.minor versions of Python.
 ## Unit tests are run in CI against these versions.
 ##
-# TODO: Add 3.14. It's currently broken with uv, not sure why.
-set -g _fish_ai_supported_versions 3.9 3.10 3.11 3.12 3.13
+set -g _fish_ai_supported_versions 3.10 3.11 3.12 3.13 3.14
 
 set -g _fish_ai_install_dir (test -z "$XDG_DATA_HOME"; and echo "$HOME/.local/share/fish-ai"; or echo "$XDG_DATA_HOME/fish-ai")
 set -g _fish_ai_config_path (test -z "$XDG_CONFIG_HOME"; and echo "$HOME/.config/fish-ai.ini"; or echo "$XDG_CONFIG_HOME/fish-ai.ini")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fish_ai"
-version = "2.4.1"
+version = "2.5.0"
 authors = [{ name = "Bastian Fredriksson", email = "realiserad@gmail.com" }]
 description = "Provides core functionality for fish-ai, an AI plugin for the fish shell."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Programming Language :: Python :: 3",
   "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Python 3.14 is now in stable. Make Python 3.14 the default Python version for new installations and make sure we run tests on 3.14 as well.

Drop support for Python 3.9 which is end of life.