### PR TITLE
fix: vim key bindings on fish v4.3+

### DIFF
--- a/conf.d/fish_ai.fish
+++ b/conf.d/fish_ai.fish
@@ -9,7 +9,7 @@ set -g _fish_ai_config_path (test -z "$XDG_CONFIG_HOME"; and echo "$HOME/.config
 
 ##
 ## This section creates the keybindings for fish-ai. Modify your `fish-ai.ini`
-## to change the keybindings from their defaults.
+## and restart the terminal emulator to change the keybindings from their defaults.
 ##
 function _fish_ai_bind --description "Create keybindings for fish-ai."
     if test -n ("$_fish_ai_install_dir/bin/lookup_setting" keymap_1)
@@ -37,8 +37,10 @@ function _fish_ai_bind --description "Create keybindings for fish-ai."
     else
         set -g _fish_ai_bind_command bind
     end
-    $_fish_ai_bind_command $_fish_ai_keymap_1 _fish_ai_codify_or_explain
-    $_fish_ai_bind_command $_fish_ai_keymap_2 _fish_ai_autocomplete_or_fix
+    bind -M insert $_fish_ai_keymap_1 _fish_ai_codify_or_explain
+    bind $_fish_ai_keymap_1 _fish_ai_codify_or_explain
+    bind -M insert $_fish_ai_keymap_2 _fish_ai_autocomplete_or_fix
+    bind $_fish_ai_keymap_2 _fish_ai_autocomplete_or_fix
 end
 
 if status is-interactive && test -d "$_fish_ai_install_dir"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fish_ai"
-version = "2.10.5"
+version = "2.10.6"
 authors = [{ name = "Bastian Fredriksson", email = "realiserad@gmail.com" }]
 description = "Provides core functionality for fish-ai, an AI plugin for the fish shell."
 readme = "README.md"


### PR DESCRIPTION
Register key bindings for both vi mode and default mode by default and stop relying on the `fish_key_bindings` environment variable, this is unnecessary and stopped working in fish v4.3+.

Closes: #531