### PR TITLE
feat(bedrock): add aws_profile support for named AWS credential profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ configuration = bedrock
 [bedrock]
 provider = bedrock
 aws_region = us-east-1
+aws_profile = my-profile
 ```
 
 If no `api_key` is configured, a short-term token is automatically
@@ -109,6 +110,9 @@ generated from your
 (SSO, IAM roles, environment variables, etc.). You can also specify
 an `api_key` directly if you prefer to use a
 [Bedrock API key](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html).
+
+Use `aws_profile` to select a named profile from your AWS configuration.
+If omitted, the default credential chain is used.
 
 This uses the Bedrock Mantle gateway which supports all models available
 on Bedrock. See the

--- a/src/fish_ai/engine.py
+++ b/src/fish_ai/engine.py
@@ -18,22 +18,22 @@ from fish_ai.config import get_config
 
 logger = logging.getLogger()
 
-if exists("/dev/log"):
+if exists('/dev/log'):
     # Syslog on Linux
-    handler = SysLogHandler(address="/dev/log")
+    handler = SysLogHandler(address='/dev/log')
     logger.addHandler(handler)
-elif exists("/var/run/syslog"):
+elif exists('/var/run/syslog'):
     # Syslog on macOS
-    handler = SysLogHandler(address="/var/run/syslog")
+    handler = SysLogHandler(address='/var/run/syslog')
     logger.addHandler(handler)
 
-if get_config("log"):
+if get_config('log'):
     handler = RotatingFileHandler(
-        expanduser(get_config("log")), backupCount=0, maxBytes=1024 * 1024
+        expanduser(get_config('log')), backupCount=0, maxBytes=1024 * 1024
     )
     logger.addHandler(handler)
 
-if get_config("debug") == "True":
+if get_config('debug') == 'True':
     logger.setLevel(logging.DEBUG)
 
 
@@ -46,36 +46,36 @@ def get_args():
 
 
 def get_os():
-    if system() == "Linux":
-        if isfile("/etc/os-release"):
-            with open("/etc/os-release") as f:
+    if system() == 'Linux':
+        if isfile('/etc/os-release'):
+            with open('/etc/os-release') as f:
                 for line in f:
-                    if line.startswith("PRETTY_NAME="):
-                        return line.split("=")[1].strip('"')
-        return "Linux"
-    if system() == "Darwin":
-        return "macOS " + mac_ver()[0]
-    return "Unknown"
+                    if line.startswith('PRETTY_NAME='):
+                        return line.split('=')[1].strip('"')
+        return 'Linux'
+    if system() == 'Darwin':
+        return 'macOS ' + mac_ver()[0]
+    return 'Unknown'
 
 
 def get_manpage(command):
     try:
         get_logger().debug('Retrieving manpage for command "{}"'.format(command))
-        helppage = run(["fish", "-c", command + " --help"], stdout=PIPE, stderr=DEVNULL)
+        helppage = run(['fish', '-c', command + ' --help'], stdout=PIPE, stderr=DEVNULL)
         if helppage.returncode == 0:
-            output = helppage.stdout.decode("utf-8")
+            output = helppage.stdout.decode('utf-8')
             if len(output) > 2000:
-                return output[:2000] + " [...]"
+                return output[:2000] + ' [...]'
             else:
                 return output
-        return "No manpage available."
+        return 'No manpage available.'
     except Exception as e:
         get_logger().debug(
             'Failed to retrieve manpage for command "{}". Reason: {}'.format(
                 command, str(e)
             )
         )
-        return "No manpage available."
+        return 'No manpage available.'
 
 
 def get_file_info(words):
@@ -84,8 +84,8 @@ def get_file_info(words):
     contents.
     """
     for word in words.split():
-        filename = word.rstrip(",.!").strip("\"'")
-        if not match(r"[A-Za-z0-9_\-]+\.[a-z]+", filename.split("/")[-1]):
+        filename = word.rstrip(',.!').strip("\"'")
+        if not match(r'[A-Za-z0-9_\-]+\.[a-z]+', filename.split('/')[-1]):
             continue
         if not isfile(filename):
             continue
@@ -93,25 +93,25 @@ def get_file_info(words):
             continue
         if is_binary(filename):
             continue
-        with open(filename, "r") as file:
-            get_logger().debug("Loading file: " + filename)
+        with open(filename, 'r') as file:
+            get_logger().debug('Loading file: ' + filename)
             return filename, file.read(3072)
     return None, None
 
 
 def get_commandline_history(commandline, cursor_position):
-    history_size = int(get_config("history_size") or 0)
+    history_size = int(get_config('history_size') or 0)
     if history_size == 0:
-        get_logger().debug("Commandline history disabled.")
-        return "No commandline history available."
+        get_logger().debug('Commandline history disabled.')
+        return 'No commandline history available.'
 
     def yield_history():
-        command = commandline.split(" ")[0]
+        command = commandline.split(' ')[0]
         before_cursor = commandline[:cursor_position]
         after_cursor = commandline[cursor_position:]
 
         proc = Popen(
-            ["fish", "-c", 'history search --prefix "{}"'.format(command)],
+            ['fish', '-c', 'history search --prefix "{}"'.format(command)],
             stdout=PIPE,
             stderr=DEVNULL,
         )
@@ -119,21 +119,21 @@ def get_commandline_history(commandline, cursor_position):
             line = proc.stdout.readline()
             if not line:
                 break
-            item = line.decode("utf-8").strip()
+            item = line.decode('utf-8').strip()
             if item.startswith(before_cursor) and item.endswith(after_cursor):
                 yield item
 
     history = list(islice(yield_history(), history_size))
 
     if len(history) == 0:
-        return "No commandline history available."
-    return "\n".join(history)
+        return 'No commandline history available.'
+    return '\n'.join(history)
 
 
 def get_system_prompt():
     return {
-        "role": "system",
-        "content": textwrap.dedent("""\
+        'role': 'system',
+        'content': textwrap.dedent("""\
         You are a shell scripting assistant working inside a fish shell.
         The operating system is {os}. Your output must to be shell runnable.
         You may consult Stack Overflow and the official Fish shell
@@ -151,15 +151,15 @@ def get_custom_headers():
 
     This is useful for authentication headers like Cloudflare Access.
     """
-    headers_config = get_config("headers")
+    headers_config = get_config('headers')
     if not headers_config:
         return None
 
     headers = {}
-    for header in headers_config.split(","):
+    for header in headers_config.split(','):
         header = header.strip()
-        if ":" in header:
-            key, value = header.split(":", 1)
+        if ':' in header:
+            key, value = header.split(':', 1)
             headers[key.strip()] = value.strip()
     return headers if headers else None
 
@@ -167,48 +167,48 @@ def get_custom_headers():
 def get_openai_client():
     custom_headers = get_custom_headers()
 
-    if get_config("provider") == "azure":
+    if get_config('provider') == 'azure':
         from openai import AzureOpenAI
 
         return AzureOpenAI(
-            azure_endpoint=get_config("server"),
-            api_version="2023-07-01-preview",
-            api_key=get_config("api_key"),
-            azure_deployment=get_config("azure_deployment"),
+            azure_endpoint=get_config('server'),
+            api_version='2023-07-01-preview',
+            api_key=get_config('api_key'),
+            azure_deployment=get_config('azure_deployment'),
             default_headers=custom_headers,
         )
-    elif get_config("provider") == "self-hosted":
+    elif get_config('provider') == 'self-hosted':
         from openai import OpenAI
 
         return OpenAI(
-            base_url=get_config("server"),
-            api_key=get_config("api_key") or "dummy",
+            base_url=get_config('server'),
+            api_key=get_config('api_key') or 'dummy',
             default_headers=custom_headers,
         )
-    elif get_config("provider") == "openai":
+    elif get_config('provider') == 'openai':
         from openai import OpenAI
 
         return OpenAI(
-            api_key=get_config("api_key"),
-            organization=get_config("organization"),
+            api_key=get_config('api_key'),
+            organization=get_config('organization'),
             default_headers=custom_headers,
         )
-    elif get_config("provider") == "deepseek":
+    elif get_config('provider') == 'deepseek':
         # DeepSeek is compatible with OpenAI Python SDK
         from openai import OpenAI
 
         return OpenAI(
-            api_key=get_config("api_key"),
-            base_url="https://api.deepseek.com",
+            api_key=get_config('api_key'),
+            base_url='https://api.deepseek.com',
             default_headers=custom_headers,
         )
-    elif get_config("provider") == "bedrock":
+    elif get_config('provider') == 'bedrock':
         from openai import OpenAI
 
-        aws_region = get_config("aws_region") or "us-east-1"
-        api_key = get_config("api_key")
+        aws_region = get_config('aws_region') or 'us-east-1'
+        api_key = get_config('api_key')
         if not api_key:
-            aws_profile = get_config("aws_profile")
+            aws_profile = get_config('aws_profile')
             if aws_profile:
                 from botocore.session import Session as BotocoreSession
                 from aws_bedrock_token_generator import BedrockTokenGenerator
@@ -228,36 +228,36 @@ def get_openai_client():
 
                 api_key = provide_token(region=aws_region)
         return OpenAI(
-            base_url="https://bedrock-mantle.{}.api.aws/v1".format(aws_region),
+            base_url='https://bedrock-mantle.{}.api.aws/v1'.format(aws_region),
             api_key=api_key,
             default_headers=custom_headers,
         )
-    elif get_config("provider") == "groq":
+    elif get_config('provider') == 'groq':
         from groq import Groq
 
         return Groq(
-            api_key=get_config("api_key"),
+            api_key=get_config('api_key'),
             default_headers=custom_headers,
         )
-    elif get_config("provider") == "cohere":
+    elif get_config('provider') == 'cohere':
         # https://docs.cohere.com/docs/compatibility-api
         from openai import OpenAI
 
         return OpenAI(
-            api_key=get_config("api_key"),
-            base_url="https://api.cohere.ai/compatibility/v1",
+            api_key=get_config('api_key'),
+            base_url='https://api.cohere.ai/compatibility/v1',
             default_headers=custom_headers,
         )
     else:
-        raise Exception('Unknown provider "{}".'.format(get_config("provider")))
+        raise Exception('Unknown provider "{}".'.format(get_config('provider')))
 
 
 def get_messages_for_anthropic(messages):
     user_messages = []
     system_messages = []
     for message in messages:
-        if message.get("role") == "system":
-            system_messages.append(message.get("content"))
+        if message.get('role') == 'system':
+            system_messages.append(message.get('content'))
         else:
             user_messages.append(message)
     return system_messages, user_messages
@@ -274,128 +274,128 @@ def get_messages_for_gemini(messages):
     system_messages = []
     other_messages = []
     for message in messages:
-        if message.get("role") == "system":
-            system_messages.append({"text": message.get("content")})
+        if message.get('role') == 'system':
+            system_messages.append({'text': message.get('content')})
         else:
             other_messages.append(message)
 
     for i in range(len(other_messages)):
         message = other_messages[i]
-        if message.get("role") == "user":
+        if message.get('role') == 'user':
             outputs.append(
                 {
-                    "role": "user",
-                    "parts": system_messages + [{"text": message.get("content")}]
+                    'role': 'user',
+                    'parts': system_messages + [{'text': message.get('content')}]
                     if i == 0
-                    else [{"text": message.get("content")}],
+                    else [{'text': message.get('content')}],
                 }
             )
-        elif message.get("role") == "assistant":
+        elif message.get('role') == 'assistant':
             outputs.append(
-                {"role": "model", "parts": [{"text": message.get("content")}]}
+                {'role': 'model', 'parts': [{'text': message.get('content')}]}
             )
     return outputs
 
 
 def create_system_prompt(messages):
-    return "\n\n".join(
+    return '\n\n'.join(
         list(
             map(
-                lambda message: message.get("content"),
-                list(filter(lambda message: message.get("role") == "system", messages)),
+                lambda message: message.get('content'),
+                list(filter(lambda message: message.get('role') == 'system', messages)),
             )
         )
     )
 
 
 def get_response(messages):
-    if get_config("redact") != "False":
+    if get_config('redact') != 'False':
         messages = redact(messages)
 
     start_time = time_ns()
 
     custom_headers = get_custom_headers()
 
-    if get_config("provider") == "mistral":
+    if get_config('provider') == 'mistral':
         from mistralai import Mistral
 
         mistral_kwargs = {
-            "api_key": get_config("api_key"),
-            "server_url": get_config("server") or "https://api.mistral.ai",
+            'api_key': get_config('api_key'),
+            'server_url': get_config('server') or 'https://api.mistral.ai',
         }
         if custom_headers:
             from httpx import Client
 
-            mistral_kwargs["http_client"] = Client(headers=custom_headers)
+            mistral_kwargs['http_client'] = Client(headers=custom_headers)
         client = Mistral(**mistral_kwargs)
         params = {
-            "model": get_config("model") or "mistral-large-latest",
-            "messages": messages,
+            'model': get_config('model') or 'mistral-large-latest',
+            'messages': messages,
         }
         completions = client.chat.complete(**params)
         response = completions.choices[0].message.content
-    elif get_config("provider") == "anthropic":
+    elif get_config('provider') == 'anthropic':
         from anthropic import Anthropic
 
         client = Anthropic(
-            api_key=get_config("api_key"),
+            api_key=get_config('api_key'),
             default_headers=custom_headers,
         )
         system_messages, user_messages = get_messages_for_anthropic(messages)
         params = {
-            "model": get_config("model") or "claude-sonnet-4-6",
-            "system": "\n".join(system_messages),
-            "messages": user_messages,
-            "max_tokens": 4096,
+            'model': get_config('model') or 'claude-sonnet-4-6',
+            'system': '\n'.join(system_messages),
+            'messages': user_messages,
+            'max_tokens': 4096,
         }
         completions = client.messages.create(**params)
         response = completions.content[0].text
-    elif get_config("provider") == "groq":
-        default_groq_model = "qwen/qwen3-32b"
-        groq_qwen_reasoning_models = ["qwen/qwen3-32b", "qwen-qwq-32b"]
-        model = get_config("model") or default_groq_model
+    elif get_config('provider') == 'groq':
+        default_groq_model = 'qwen/qwen3-32b'
+        groq_qwen_reasoning_models = ['qwen/qwen3-32b', 'qwen-qwq-32b']
+        model = get_config('model') or default_groq_model
         params = {
-            "model": model,
-            "messages": messages,
-            "stream": False,
-            "max_completion_tokens": 4096,
-            "top_p": 0.95,
-            "n": 1,
+            'model': model,
+            'messages': messages,
+            'stream': False,
+            'max_completion_tokens': 4096,
+            'top_p': 0.95,
+            'n': 1,
         }
         # This removes the thinking tokens for the qwen-qwq-32b model:
         if model in groq_qwen_reasoning_models:
-            params["reasoning_format"] = "parsed"
+            params['reasoning_format'] = 'parsed'
         completions = get_openai_client().chat.completions.create(**params)
         response = completions.choices[0].message.content
-    elif get_config("provider") == "google":
+    elif get_config('provider') == 'google':
         from google import genai
         from google.genai import types
 
-        google_kwargs = {"api_key": get_config("api_key")}
+        google_kwargs = {'api_key': get_config('api_key')}
         if custom_headers:
             from google.genai.types import HttpOptions
 
-            google_kwargs["http_options"] = HttpOptions(headers=custom_headers)
+            google_kwargs['http_options'] = HttpOptions(headers=custom_headers)
         client = genai.Client(**google_kwargs)
-        model = get_config("model") or "gemini-3.1-pro-preview"
+        model = get_config('model') or 'gemini-3.1-pro-preview'
 
         model_info = client.models.get(model=model)
-        if not getattr(model_info, "thinking", False):
+        if not getattr(model_info, 'thinking', False):
             thinking_config = types.GenerateContentConfig()
-        elif "gemini-2.5" in model:
+        elif 'gemini-2.5' in model:
             # Gemini 2.5 uses thinking_budget (512 to 32768 tokens)
             # Note: gemini-2.5-flash-lite supports 512 to 24576 tokens
             thinking_config = types.ThinkingConfig(thinking_budget=1024)
-        elif "gemini-3" in model:
+        elif 'gemini-3' in model:
             # Gemini 3 uses thinking_level (one of
             # ['minimal', 'low', 'medium', 'high'])
-            thinking_config = types.ThinkingConfig(thinking_level="low")
+            thinking_config = types.ThinkingConfig(thinking_level='low')
         else:
             get_logger().debug(
                 (
                     f"Unknown model '{model}'. Making API call without a "
-                    "thinking config. If this is unexpected, file a feature "
-                    "request at https://github.com/Realiserad/fish-ai/issues"
+                    'thinking config. If this is unexpected, file a feature '
+                    'request at https://github.com/Realiserad/fish-ai/issues'
                 )
             )
             thinking_config = None
@@ -406,22 +406,22 @@ def get_response(messages):
         ).text
     else:
         params = {
-            "model": get_config("model") or "gpt-4o",
-            "messages": messages,
-            "stream": False,
-            "n": 1,
+            'model': get_config('model') or 'gpt-4o',
+            'messages': messages,
+            'stream': False,
+            'n': 1,
         }
-        if get_config("extra_body"):
+        if get_config('extra_body'):
             import json
 
-            params["extra_body"] = json.loads(get_config("extra_body"))
+            params['extra_body'] = json.loads(get_config('extra_body'))
         completions = get_openai_client().chat.completions.create(**params)
         response = completions.choices[0].message.content
 
     end_time = time_ns()
-    get_logger().debug("Response received from backend: " + repr(response))
+    get_logger().debug('Response received from backend: ' + repr(response))
     get_logger().debug(
-        "Processing time: " + str(round((end_time - start_time) / 1000000)) + " ms."
+        'Processing time: ' + str(round((end_time - start_time) / 1000000)) + ' ms.'
     )
     return remove_thinking_tokens(response)
 
@@ -438,12 +438,12 @@ def remove_thinking_tokens(response):
     :param response: The response from the backend.
     :return: The output without any thinking tokens.
     """
-    if not response.strip().startswith("<think>"):
+    if not response.strip().startswith('<think>'):
         return response.strip()
 
     import re
 
-    match = re.search(r"<think>(.*?)</think>(.*)", response, re.DOTALL)
+    match = re.search(r'<think>(.*?)</think>(.*)', response, re.DOTALL)
     if match:
         return match.group(2).strip()
     else:
@@ -451,7 +451,7 @@ def remove_thinking_tokens(response):
 
 
 def get_install_dir():
-    if "XDG_DATA_HOME" in environ:
-        return expandvars("$XDG_DATA_HOME/fish-ai")
+    if 'XDG_DATA_HOME' in environ:
+        return expandvars('$XDG_DATA_HOME/fish-ai')
     else:
-        return expanduser("~/.local/share/fish-ai")
+        return expanduser('~/.local/share/fish-ai')

--- a/src/fish_ai/engine.py
+++ b/src/fish_ai/engine.py
@@ -18,22 +18,22 @@ from fish_ai.config import get_config
 
 logger = logging.getLogger()
 
-if exists('/dev/log'):
+if exists("/dev/log"):
     # Syslog on Linux
-    handler = SysLogHandler(address='/dev/log')
+    handler = SysLogHandler(address="/dev/log")
     logger.addHandler(handler)
-elif exists('/var/run/syslog'):
+elif exists("/var/run/syslog"):
     # Syslog on macOS
-    handler = SysLogHandler(address='/var/run/syslog')
+    handler = SysLogHandler(address="/var/run/syslog")
     logger.addHandler(handler)
 
-if get_config('log'):
-    handler = RotatingFileHandler(expanduser(get_config('log')),
-                                  backupCount=0,
-                                  maxBytes=1024*1024)
+if get_config("log"):
+    handler = RotatingFileHandler(
+        expanduser(get_config("log")), backupCount=0, maxBytes=1024 * 1024
+    )
     logger.addHandler(handler)
 
-if get_config('debug') == 'True':
+if get_config("debug") == "True":
     logger.setLevel(logging.DEBUG)
 
 
@@ -46,38 +46,36 @@ def get_args():
 
 
 def get_os():
-    if system() == 'Linux':
-        if isfile('/etc/os-release'):
-            with open('/etc/os-release') as f:
+    if system() == "Linux":
+        if isfile("/etc/os-release"):
+            with open("/etc/os-release") as f:
                 for line in f:
-                    if line.startswith('PRETTY_NAME='):
-                        return line.split('=')[1].strip('"')
-        return 'Linux'
-    if system() == 'Darwin':
-        return 'macOS ' + mac_ver()[0]
-    return 'Unknown'
+                    if line.startswith("PRETTY_NAME="):
+                        return line.split("=")[1].strip('"')
+        return "Linux"
+    if system() == "Darwin":
+        return "macOS " + mac_ver()[0]
+    return "Unknown"
 
 
 def get_manpage(command):
     try:
-        get_logger().debug('Retrieving manpage for command "{}"'
-                           .format(command))
-        helppage = run(
-            ['fish', '-c', command + ' --help'],
-            stdout=PIPE,
-            stderr=DEVNULL)
+        get_logger().debug('Retrieving manpage for command "{}"'.format(command))
+        helppage = run(["fish", "-c", command + " --help"], stdout=PIPE, stderr=DEVNULL)
         if helppage.returncode == 0:
-            output = helppage.stdout.decode('utf-8')
+            output = helppage.stdout.decode("utf-8")
             if len(output) > 2000:
-                return output[:2000] + ' [...]'
+                return output[:2000] + " [...]"
             else:
                 return output
-        return 'No manpage available.'
+        return "No manpage available."
     except Exception as e:
         get_logger().debug(
             'Failed to retrieve manpage for command "{}". Reason: {}'.format(
-                command, str(e)))
-        return 'No manpage available.'
+                command, str(e)
+            )
+        )
+        return "No manpage available."
 
 
 def get_file_info(words):
@@ -86,8 +84,8 @@ def get_file_info(words):
     contents.
     """
     for word in words.split():
-        filename = word.rstrip(',.!').strip('"\'')
-        if not match(r'[A-Za-z0-9_\-]+\.[a-z]+', filename.split('/')[-1]):
+        filename = word.rstrip(",.!").strip("\"'")
+        if not match(r"[A-Za-z0-9_\-]+\.[a-z]+", filename.split("/")[-1]):
             continue
         if not isfile(filename):
             continue
@@ -95,51 +93,52 @@ def get_file_info(words):
             continue
         if is_binary(filename):
             continue
-        with open(filename, 'r') as file:
-            get_logger().debug('Loading file: ' + filename)
+        with open(filename, "r") as file:
+            get_logger().debug("Loading file: " + filename)
             return filename, file.read(3072)
     return None, None
 
 
 def get_commandline_history(commandline, cursor_position):
-    history_size = int(get_config('history_size') or 0)
+    history_size = int(get_config("history_size") or 0)
     if history_size == 0:
-        get_logger().debug('Commandline history disabled.')
-        return 'No commandline history available.'
+        get_logger().debug("Commandline history disabled.")
+        return "No commandline history available."
 
     def yield_history():
-        command = commandline.split(' ')[0]
+        command = commandline.split(" ")[0]
         before_cursor = commandline[:cursor_position]
         after_cursor = commandline[cursor_position:]
 
         proc = Popen(
-            ['fish', '-c', 'history search --prefix "{}"'.format(command)],
+            ["fish", "-c", 'history search --prefix "{}"'.format(command)],
             stdout=PIPE,
-            stderr=DEVNULL)
+            stderr=DEVNULL,
+        )
         while True:
             line = proc.stdout.readline()
             if not line:
                 break
-            item = line.decode('utf-8').strip()
+            item = line.decode("utf-8").strip()
             if item.startswith(before_cursor) and item.endswith(after_cursor):
                 yield item
 
     history = list(islice(yield_history(), history_size))
 
     if len(history) == 0:
-        return 'No commandline history available.'
-    return '\n'.join(history)
+        return "No commandline history available."
+    return "\n".join(history)
 
 
 def get_system_prompt():
     return {
-        'role': 'system',
-        'content': textwrap.dedent('''\
+        "role": "system",
+        "content": textwrap.dedent("""\
         You are a shell scripting assistant working inside a fish shell.
         The operating system is {os}. Your output must to be shell runnable.
         You may consult Stack Overflow and the official Fish shell
         documentation for answers.
-        ''').format(os=get_os())
+        """).format(os=get_os()),
     }
 
 
@@ -152,15 +151,15 @@ def get_custom_headers():
 
     This is useful for authentication headers like Cloudflare Access.
     """
-    headers_config = get_config('headers')
+    headers_config = get_config("headers")
     if not headers_config:
         return None
 
     headers = {}
-    for header in headers_config.split(','):
+    for header in headers_config.split(","):
         header = header.strip()
-        if ':' in header:
-            key, value = header.split(':', 1)
+        if ":" in header:
+            key, value = header.split(":", 1)
             headers[key.strip()] = value.strip()
     return headers if headers else None
 
@@ -168,74 +167,97 @@ def get_custom_headers():
 def get_openai_client():
     custom_headers = get_custom_headers()
 
-    if (get_config('provider') == 'azure'):
+    if get_config("provider") == "azure":
         from openai import AzureOpenAI
+
         return AzureOpenAI(
-            azure_endpoint=get_config('server'),
-            api_version='2023-07-01-preview',
-            api_key=get_config('api_key'),
-            azure_deployment=get_config('azure_deployment'),
+            azure_endpoint=get_config("server"),
+            api_version="2023-07-01-preview",
+            api_key=get_config("api_key"),
+            azure_deployment=get_config("azure_deployment"),
             default_headers=custom_headers,
         )
-    elif (get_config('provider') == 'self-hosted'):
+    elif get_config("provider") == "self-hosted":
         from openai import OpenAI
+
         return OpenAI(
-            base_url=get_config('server'),
-            api_key=get_config('api_key') or 'dummy',
+            base_url=get_config("server"),
+            api_key=get_config("api_key") or "dummy",
             default_headers=custom_headers,
         )
-    elif (get_config('provider') == 'openai'):
+    elif get_config("provider") == "openai":
         from openai import OpenAI
+
         return OpenAI(
-            api_key=get_config('api_key'),
-            organization=get_config('organization'),
+            api_key=get_config("api_key"),
+            organization=get_config("organization"),
             default_headers=custom_headers,
         )
-    elif (get_config('provider') == 'deepseek'):
+    elif get_config("provider") == "deepseek":
         # DeepSeek is compatible with OpenAI Python SDK
         from openai import OpenAI
+
         return OpenAI(
-            api_key=get_config('api_key'),
-            base_url='https://api.deepseek.com',
+            api_key=get_config("api_key"),
+            base_url="https://api.deepseek.com",
             default_headers=custom_headers,
         )
-    elif (get_config('provider') == 'bedrock'):
+    elif get_config("provider") == "bedrock":
         from openai import OpenAI
-        aws_region = get_config('aws_region') or 'us-east-1'
-        api_key = get_config('api_key')
+
+        aws_region = get_config("aws_region") or "us-east-1"
+        api_key = get_config("api_key")
         if not api_key:
-            from aws_bedrock_token_generator import provide_token
-            api_key = provide_token(region=aws_region)
+            aws_profile = get_config("aws_profile")
+            if aws_profile:
+                from botocore.session import Session as BotocoreSession
+                from aws_bedrock_token_generator import BedrockTokenGenerator
+
+                session = BotocoreSession(profile=aws_profile)
+                credentials = session.get_credentials()
+                if credentials is None:
+                    raise RuntimeError(
+                        'No AWS credentials found for profile "{}".'.format(aws_profile)
+                    )
+                api_key = BedrockTokenGenerator().get_token(
+                    credentials=credentials,
+                    region=aws_region,
+                )
+            else:
+                from aws_bedrock_token_generator import provide_token
+
+                api_key = provide_token(region=aws_region)
         return OpenAI(
-            base_url='https://bedrock-mantle.{}.api.aws/v1'.format(aws_region),
+            base_url="https://bedrock-mantle.{}.api.aws/v1".format(aws_region),
             api_key=api_key,
             default_headers=custom_headers,
         )
-    elif (get_config('provider') == 'groq'):
+    elif get_config("provider") == "groq":
         from groq import Groq
+
         return Groq(
-            api_key=get_config('api_key'),
+            api_key=get_config("api_key"),
             default_headers=custom_headers,
         )
-    elif (get_config('provider') == 'cohere'):
+    elif get_config("provider") == "cohere":
         # https://docs.cohere.com/docs/compatibility-api
         from openai import OpenAI
+
         return OpenAI(
-            api_key=get_config('api_key'),
-            base_url='https://api.cohere.ai/compatibility/v1',
+            api_key=get_config("api_key"),
+            base_url="https://api.cohere.ai/compatibility/v1",
             default_headers=custom_headers,
         )
     else:
-        raise Exception('Unknown provider "{}".'
-                        .format(get_config('provider')))
+        raise Exception('Unknown provider "{}".'.format(get_config("provider")))
 
 
 def get_messages_for_anthropic(messages):
     user_messages = []
     system_messages = []
     for message in messages:
-        if message.get('role') == 'system':
-            system_messages.append(message.get('content'))
+        if message.get("role") == "system":
+            system_messages.append(message.get("content"))
         else:
             user_messages.append(message)
     return system_messages, user_messages
@@ -252,144 +274,155 @@ def get_messages_for_gemini(messages):
     system_messages = []
     other_messages = []
     for message in messages:
-        if message.get('role') == 'system':
-            system_messages.append({'text': message.get('content')})
+        if message.get("role") == "system":
+            system_messages.append({"text": message.get("content")})
         else:
             other_messages.append(message)
 
     for i in range(len(other_messages)):
         message = other_messages[i]
-        if message.get('role') == 'user':
-            outputs.append({
-                'role': 'user',
-                'parts': system_messages + [{'text': message.get('content')}]
-                if i == 0 else [{'text': message.get('content')}]
-            })
-        elif message.get('role') == 'assistant':
-            outputs.append({
-                'role': 'model',
-                'parts': [{'text': message.get('content')}]
-            })
+        if message.get("role") == "user":
+            outputs.append(
+                {
+                    "role": "user",
+                    "parts": system_messages + [{"text": message.get("content")}]
+                    if i == 0
+                    else [{"text": message.get("content")}],
+                }
+            )
+        elif message.get("role") == "assistant":
+            outputs.append(
+                {"role": "model", "parts": [{"text": message.get("content")}]}
+            )
     return outputs
 
 
 def create_system_prompt(messages):
-    return '\n\n'.join(
+    return "\n\n".join(
         list(
-            map(lambda message: message.get('content'),
-                list(
-                    filter(
-                        lambda message: message.get('role') == 'system',
-                        messages)))))
+            map(
+                lambda message: message.get("content"),
+                list(filter(lambda message: message.get("role") == "system", messages)),
+            )
+        )
+    )
 
 
 def get_response(messages):
-    if get_config('redact') != 'False':
+    if get_config("redact") != "False":
         messages = redact(messages)
 
     start_time = time_ns()
 
     custom_headers = get_custom_headers()
 
-    if get_config('provider') == 'mistral':
+    if get_config("provider") == "mistral":
         from mistralai import Mistral
 
         mistral_kwargs = {
-            'api_key': get_config('api_key'),
-            'server_url': get_config('server') or 'https://api.mistral.ai',
+            "api_key": get_config("api_key"),
+            "server_url": get_config("server") or "https://api.mistral.ai",
         }
         if custom_headers:
             from httpx import Client
-            mistral_kwargs['http_client'] = Client(headers=custom_headers)
+
+            mistral_kwargs["http_client"] = Client(headers=custom_headers)
         client = Mistral(**mistral_kwargs)
         params = {
-            'model': get_config('model') or 'mistral-large-latest',
-            'messages': messages,
+            "model": get_config("model") or "mistral-large-latest",
+            "messages": messages,
         }
         completions = client.chat.complete(**params)
         response = completions.choices[0].message.content
-    elif get_config('provider') == 'anthropic':
+    elif get_config("provider") == "anthropic":
         from anthropic import Anthropic
 
         client = Anthropic(
-            api_key=get_config('api_key'),
+            api_key=get_config("api_key"),
             default_headers=custom_headers,
         )
         system_messages, user_messages = get_messages_for_anthropic(messages)
         params = {
-            'model': get_config('model') or 'claude-sonnet-4-6',
-            'system': '\n'.join(system_messages),
-            'messages': user_messages,
-            'max_tokens': 4096
+            "model": get_config("model") or "claude-sonnet-4-6",
+            "system": "\n".join(system_messages),
+            "messages": user_messages,
+            "max_tokens": 4096,
         }
         completions = client.messages.create(**params)
         response = completions.content[0].text
-    elif get_config('provider') == 'groq':
-        default_groq_model = 'qwen/qwen3-32b'
-        groq_qwen_reasoning_models = ['qwen/qwen3-32b', 'qwen-qwq-32b']
-        model = get_config('model') or default_groq_model
+    elif get_config("provider") == "groq":
+        default_groq_model = "qwen/qwen3-32b"
+        groq_qwen_reasoning_models = ["qwen/qwen3-32b", "qwen-qwq-32b"]
+        model = get_config("model") or default_groq_model
         params = {
-            'model': model,
-            'messages': messages,
-            'stream': False,
-            'max_completion_tokens': 4096,
-            'top_p': 0.95,
-            'n': 1,
+            "model": model,
+            "messages": messages,
+            "stream": False,
+            "max_completion_tokens": 4096,
+            "top_p": 0.95,
+            "n": 1,
         }
         # This removes the thinking tokens for the qwen-qwq-32b model:
         if model in groq_qwen_reasoning_models:
-            params['reasoning_format'] = 'parsed'
+            params["reasoning_format"] = "parsed"
         completions = get_openai_client().chat.completions.create(**params)
         response = completions.choices[0].message.content
-    elif get_config('provider') == 'google':
+    elif get_config("provider") == "google":
         from google import genai
         from google.genai import types
-        google_kwargs = {'api_key': get_config('api_key')}
+
+        google_kwargs = {"api_key": get_config("api_key")}
         if custom_headers:
             from google.genai.types import HttpOptions
-            google_kwargs['http_options'] = HttpOptions(headers=custom_headers)
+
+            google_kwargs["http_options"] = HttpOptions(headers=custom_headers)
         client = genai.Client(**google_kwargs)
-        model = get_config('model') or 'gemini-3.1-pro-preview'
+        model = get_config("model") or "gemini-3.1-pro-preview"
 
         model_info = client.models.get(model=model)
-        if not getattr(model_info, 'thinking', False):
+        if not getattr(model_info, "thinking", False):
             thinking_config = types.GenerateContentConfig()
-        elif 'gemini-2.5' in model:
+        elif "gemini-2.5" in model:
             # Gemini 2.5 uses thinking_budget (512 to 32768 tokens)
             # Note: gemini-2.5-flash-lite supports 512 to 24576 tokens
             thinking_config = types.ThinkingConfig(thinking_budget=1024)
-        elif 'gemini-3' in model:
+        elif "gemini-3" in model:
             # Gemini 3 uses thinking_level (one of
             # ['minimal', 'low', 'medium', 'high'])
-            thinking_config = types.ThinkingConfig(thinking_level='low')
+            thinking_config = types.ThinkingConfig(thinking_level="low")
         else:
             get_logger().debug(
-                (f"Unknown model '{model}'. Making API call without a "
-                 'thinking config. If this is unexpected, file a feature '
-                 'request at https://github.com/Realiserad/fish-ai/issues'))
+                (
+                    f"Unknown model '{model}'. Making API call without a "
+                    "thinking config. If this is unexpected, file a feature "
+                    "request at https://github.com/Realiserad/fish-ai/issues"
+                )
+            )
             thinking_config = None
         response = client.models.generate_content(
             model=model,
             contents=get_messages_for_gemini(messages),
-            config=types.GenerateContentConfig(thinking_config=thinking_config)
+            config=types.GenerateContentConfig(thinking_config=thinking_config),
         ).text
     else:
         params = {
-            'model': get_config('model') or 'gpt-4o',
-            'messages': messages,
-            'stream': False,
-            'n': 1,
+            "model": get_config("model") or "gpt-4o",
+            "messages": messages,
+            "stream": False,
+            "n": 1,
         }
-        if get_config('extra_body'):
+        if get_config("extra_body"):
             import json
-            params['extra_body'] = json.loads(get_config('extra_body'))
+
+            params["extra_body"] = json.loads(get_config("extra_body"))
         completions = get_openai_client().chat.completions.create(**params)
         response = completions.choices[0].message.content
 
     end_time = time_ns()
-    get_logger().debug('Response received from backend: ' + repr(response))
-    get_logger().debug('Processing time: ' +
-                       str(round((end_time - start_time) / 1000000)) + ' ms.')
+    get_logger().debug("Response received from backend: " + repr(response))
+    get_logger().debug(
+        "Processing time: " + str(round((end_time - start_time) / 1000000)) + " ms."
+    )
     return remove_thinking_tokens(response)
 
 
@@ -405,11 +438,12 @@ def remove_thinking_tokens(response):
     :param response: The response from the backend.
     :return: The output without any thinking tokens.
     """
-    if not response.strip().startswith('<think>'):
+    if not response.strip().startswith("<think>"):
         return response.strip()
 
     import re
-    match = re.search(r'<think>(.*?)</think>(.*)', response, re.DOTALL)
+
+    match = re.search(r"<think>(.*?)</think>(.*)", response, re.DOTALL)
     if match:
         return match.group(2).strip()
     else:
@@ -417,7 +451,7 @@ def remove_thinking_tokens(response):
 
 
 def get_install_dir():
-    if 'XDG_DATA_HOME' in environ:
-        return expandvars('$XDG_DATA_HOME/fish-ai')
+    if "XDG_DATA_HOME" in environ:
+        return expandvars("$XDG_DATA_HOME/fish-ai")
     else:
-        return expanduser('~/.local/share/fish-ai')
+        return expanduser("~/.local/share/fish-ai")

--- a/src/fish_ai/tests/engine_test.py
+++ b/src/fish_ai/tests/engine_test.py
@@ -4,112 +4,169 @@ from unittest.mock import patch, MagicMock
 from fish_ai.engine import get_commandline_history, get_response
 
 
-@patch('fish_ai.engine.get_config')
-@patch('fish_ai.engine.get_logger')
+@patch("fish_ai.engine.get_config")
+@patch("fish_ai.engine.get_logger")
 def test_get_commandline_history_disabled(mock_get_logger, mock_get_config):
-    mock_get_config.return_value = '0'
-    assert get_commandline_history('command', 0) == \
-        'No commandline history available.'
+    mock_get_config.return_value = "0"
+    assert get_commandline_history("command", 0) == "No commandline history available."
     mock_get_logger.assert_called_once()
 
 
-@patch('fish_ai.engine.get_config')
+@patch("fish_ai.engine.get_config")
 def test_bedrock_happy_path(mock_get_config):
     def config_side_effect(key):
         config = {
-            'provider': 'bedrock',
-            'aws_region': 'us-west-2',
-            'api_key': 'test-api-key',
-            'model': 'anthropic.claude-sonnet-4-6-20250514-v1:0',
-            'redact': 'False',
+            "provider": "bedrock",
+            "aws_region": "us-west-2",
+            "api_key": "test-api-key",
+            "model": "anthropic.claude-sonnet-4-6-20250514-v1:0",
+            "redact": "False",
         }
         return config.get(key)
+
     mock_get_config.side_effect = config_side_effect
 
     mock_completions = MagicMock()
-    mock_completions.choices = [
-        MagicMock(message=MagicMock(content='echo hello'))
-    ]
+    mock_completions.choices = [MagicMock(message=MagicMock(content="echo hello"))]
     mock_client = MagicMock()
     mock_client.chat.completions.create.return_value = mock_completions
 
-    with patch('fish_ai.engine.get_openai_client',
-               return_value=mock_client) as mock_get_client:
-        response = get_response([
-            {'role': 'system', 'content': 'You are helpful.'},
-            {'role': 'user', 'content': 'hello'}
-        ])
+    with patch(
+        "fish_ai.engine.get_openai_client", return_value=mock_client
+    ) as mock_get_client:
+        response = get_response(
+            [
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "hello"},
+            ]
+        )
         mock_get_client.assert_called_once()
         mock_client.chat.completions.create.assert_called_once()
         call_kwargs = mock_client.chat.completions.create.call_args[1]
-        assert call_kwargs['model'] == \
-            'anthropic.claude-sonnet-4-6-20250514-v1:0'
-        assert response == 'echo hello'
+        assert call_kwargs["model"] == "anthropic.claude-sonnet-4-6-20250514-v1:0"
+        assert response == "echo hello"
 
 
-@patch('fish_ai.engine.get_config')
+@patch("fish_ai.engine.get_config")
 def test_bedrock_constructs_mantle_url(mock_get_config):
     def config_side_effect(key):
         config = {
-            'provider': 'bedrock',
-            'aws_region': 'eu-west-1',
-            'api_key': 'test-key',
+            "provider": "bedrock",
+            "aws_region": "eu-west-1",
+            "api_key": "test-key",
         }
         return config.get(key)
+
     mock_get_config.side_effect = config_side_effect
 
-    with patch('openai.OpenAI') as mock_openai_cls:
+    with patch("openai.OpenAI") as mock_openai_cls:
         from fish_ai.engine import get_openai_client
+
         get_openai_client()
         mock_openai_cls.assert_called_once_with(
-            base_url='https://bedrock-mantle.eu-west-1.api.aws/v1',
-            api_key='test-key',
+            base_url="https://bedrock-mantle.eu-west-1.api.aws/v1",
+            api_key="test-key",
             default_headers=None,
         )
 
 
-@patch('fish_ai.engine.get_config')
+@patch("fish_ai.engine.get_config")
 def test_bedrock_default_region(mock_get_config):
     def config_side_effect(key):
         config = {
-            'provider': 'bedrock',
-            'api_key': 'test-key',
+            "provider": "bedrock",
+            "api_key": "test-key",
         }
         return config.get(key)
+
     mock_get_config.side_effect = config_side_effect
 
-    with patch('openai.OpenAI') as mock_openai_cls:
+    with patch("openai.OpenAI") as mock_openai_cls:
         from fish_ai.engine import get_openai_client
+
         get_openai_client()
         mock_openai_cls.assert_called_once_with(
-            base_url='https://bedrock-mantle.us-east-1.api.aws/v1',
-            api_key='test-key',
+            base_url="https://bedrock-mantle.us-east-1.api.aws/v1",
+            api_key="test-key",
             default_headers=None,
         )
 
 
-@patch('fish_ai.engine.get_config')
+@patch("fish_ai.engine.get_config")
 def test_bedrock_auto_token_when_no_api_key(mock_get_config):
     def config_side_effect(key):
         config = {
-            'provider': 'bedrock',
-            'aws_region': 'us-west-2',
+            "provider": "bedrock",
+            "aws_region": "us-west-2",
         }
         return config.get(key)
+
     mock_get_config.side_effect = config_side_effect
 
     import sys
+
     mock_token_module = MagicMock()
-    mock_token_module.provide_token.return_value = 'auto-generated-token'
-    with patch.dict(sys.modules,
-                    {'aws_bedrock_token_generator': mock_token_module}):
-        with patch('openai.OpenAI') as mock_openai_cls:
+    mock_token_module.provide_token.return_value = "auto-generated-token"
+    with patch.dict(sys.modules, {"aws_bedrock_token_generator": mock_token_module}):
+        with patch("openai.OpenAI") as mock_openai_cls:
             from fish_ai.engine import get_openai_client
+
             get_openai_client()
-            mock_token_module.provide_token.assert_called_once_with(
-                region='us-west-2')
+            mock_token_module.provide_token.assert_called_once_with(region="us-west-2")
             mock_openai_cls.assert_called_once_with(
-                base_url='https://bedrock-mantle.us-west-2.api.aws/v1',
-                api_key='auto-generated-token',
+                base_url="https://bedrock-mantle.us-west-2.api.aws/v1",
+                api_key="auto-generated-token",
+                default_headers=None,
+            )
+
+
+@patch("fish_ai.engine.get_config")
+def test_bedrock_uses_aws_profile_for_token(mock_get_config):
+    def config_side_effect(key):
+        config = {
+            "provider": "bedrock",
+            "aws_region": "us-west-2",
+            "aws_profile": "my-profile",
+        }
+        return config.get(key)
+
+    mock_get_config.side_effect = config_side_effect
+
+    import sys
+
+    mock_credentials = MagicMock()
+    mock_session = MagicMock()
+    mock_session.get_credentials.return_value = mock_credentials
+
+    mock_token_generator = MagicMock()
+    mock_token_generator.get_token.return_value = "profile-token"
+
+    mock_token_module = MagicMock()
+    mock_token_module.BedrockTokenGenerator.return_value = mock_token_generator
+
+    mock_botocore_module = MagicMock()
+    mock_botocore_module.Session.return_value = mock_session
+
+    with patch.dict(
+        sys.modules,
+        {
+            "aws_bedrock_token_generator": mock_token_module,
+            "botocore.session": mock_botocore_module,
+            "botocore": MagicMock(),
+        },
+    ):
+        with patch("openai.OpenAI") as mock_openai_cls:
+            from fish_ai.engine import get_openai_client
+
+            get_openai_client()
+            mock_botocore_module.Session.assert_called_once_with(profile="my-profile")
+            mock_session.get_credentials.assert_called_once()
+            mock_token_generator.get_token.assert_called_once_with(
+                credentials=mock_credentials,
+                region="us-west-2",
+            )
+            mock_openai_cls.assert_called_once_with(
+                base_url="https://bedrock-mantle.us-west-2.api.aws/v1",
+                api_key="profile-token",
                 default_headers=None,
             )

--- a/src/fish_ai/tests/engine_test.py
+++ b/src/fish_ai/tests/engine_test.py
@@ -4,100 +4,100 @@ from unittest.mock import patch, MagicMock
 from fish_ai.engine import get_commandline_history, get_response
 
 
-@patch("fish_ai.engine.get_config")
-@patch("fish_ai.engine.get_logger")
+@patch('fish_ai.engine.get_config')
+@patch('fish_ai.engine.get_logger')
 def test_get_commandline_history_disabled(mock_get_logger, mock_get_config):
-    mock_get_config.return_value = "0"
-    assert get_commandline_history("command", 0) == "No commandline history available."
+    mock_get_config.return_value = '0'
+    assert get_commandline_history('command', 0) == 'No commandline history available.'
     mock_get_logger.assert_called_once()
 
 
-@patch("fish_ai.engine.get_config")
+@patch('fish_ai.engine.get_config')
 def test_bedrock_happy_path(mock_get_config):
     def config_side_effect(key):
         config = {
-            "provider": "bedrock",
-            "aws_region": "us-west-2",
-            "api_key": "test-api-key",
-            "model": "anthropic.claude-sonnet-4-6-20250514-v1:0",
-            "redact": "False",
+            'provider': 'bedrock',
+            'aws_region': 'us-west-2',
+            'api_key': 'test-api-key',
+            'model': 'anthropic.claude-sonnet-4-6-20250514-v1:0',
+            'redact': 'False',
         }
         return config.get(key)
 
     mock_get_config.side_effect = config_side_effect
 
     mock_completions = MagicMock()
-    mock_completions.choices = [MagicMock(message=MagicMock(content="echo hello"))]
+    mock_completions.choices = [MagicMock(message=MagicMock(content='echo hello'))]
     mock_client = MagicMock()
     mock_client.chat.completions.create.return_value = mock_completions
 
     with patch(
-        "fish_ai.engine.get_openai_client", return_value=mock_client
+        'fish_ai.engine.get_openai_client', return_value=mock_client
     ) as mock_get_client:
         response = get_response(
             [
-                {"role": "system", "content": "You are helpful."},
-                {"role": "user", "content": "hello"},
+                {'role': 'system', 'content': 'You are helpful.'},
+                {'role': 'user', 'content': 'hello'},
             ]
         )
         mock_get_client.assert_called_once()
         mock_client.chat.completions.create.assert_called_once()
         call_kwargs = mock_client.chat.completions.create.call_args[1]
-        assert call_kwargs["model"] == "anthropic.claude-sonnet-4-6-20250514-v1:0"
-        assert response == "echo hello"
+        assert call_kwargs['model'] == 'anthropic.claude-sonnet-4-6-20250514-v1:0'
+        assert response == 'echo hello'
 
 
-@patch("fish_ai.engine.get_config")
+@patch('fish_ai.engine.get_config')
 def test_bedrock_constructs_mantle_url(mock_get_config):
     def config_side_effect(key):
         config = {
-            "provider": "bedrock",
-            "aws_region": "eu-west-1",
-            "api_key": "test-key",
+            'provider': 'bedrock',
+            'aws_region': 'eu-west-1',
+            'api_key': 'test-key',
         }
         return config.get(key)
 
     mock_get_config.side_effect = config_side_effect
 
-    with patch("openai.OpenAI") as mock_openai_cls:
+    with patch('openai.OpenAI') as mock_openai_cls:
         from fish_ai.engine import get_openai_client
 
         get_openai_client()
         mock_openai_cls.assert_called_once_with(
-            base_url="https://bedrock-mantle.eu-west-1.api.aws/v1",
-            api_key="test-key",
+            base_url='https://bedrock-mantle.eu-west-1.api.aws/v1',
+            api_key='test-key',
             default_headers=None,
         )
 
 
-@patch("fish_ai.engine.get_config")
+@patch('fish_ai.engine.get_config')
 def test_bedrock_default_region(mock_get_config):
     def config_side_effect(key):
         config = {
-            "provider": "bedrock",
-            "api_key": "test-key",
+            'provider': 'bedrock',
+            'api_key': 'test-key',
         }
         return config.get(key)
 
     mock_get_config.side_effect = config_side_effect
 
-    with patch("openai.OpenAI") as mock_openai_cls:
+    with patch('openai.OpenAI') as mock_openai_cls:
         from fish_ai.engine import get_openai_client
 
         get_openai_client()
         mock_openai_cls.assert_called_once_with(
-            base_url="https://bedrock-mantle.us-east-1.api.aws/v1",
-            api_key="test-key",
+            base_url='https://bedrock-mantle.us-east-1.api.aws/v1',
+            api_key='test-key',
             default_headers=None,
         )
 
 
-@patch("fish_ai.engine.get_config")
+@patch('fish_ai.engine.get_config')
 def test_bedrock_auto_token_when_no_api_key(mock_get_config):
     def config_side_effect(key):
         config = {
-            "provider": "bedrock",
-            "aws_region": "us-west-2",
+            'provider': 'bedrock',
+            'aws_region': 'us-west-2',
         }
         return config.get(key)
 
@@ -106,27 +106,27 @@ def test_bedrock_auto_token_when_no_api_key(mock_get_config):
     import sys
 
     mock_token_module = MagicMock()
-    mock_token_module.provide_token.return_value = "auto-generated-token"
-    with patch.dict(sys.modules, {"aws_bedrock_token_generator": mock_token_module}):
-        with patch("openai.OpenAI") as mock_openai_cls:
+    mock_token_module.provide_token.return_value = 'auto-generated-token'
+    with patch.dict(sys.modules, {'aws_bedrock_token_generator': mock_token_module}):
+        with patch('openai.OpenAI') as mock_openai_cls:
             from fish_ai.engine import get_openai_client
 
             get_openai_client()
-            mock_token_module.provide_token.assert_called_once_with(region="us-west-2")
+            mock_token_module.provide_token.assert_called_once_with(region='us-west-2')
             mock_openai_cls.assert_called_once_with(
-                base_url="https://bedrock-mantle.us-west-2.api.aws/v1",
-                api_key="auto-generated-token",
+                base_url='https://bedrock-mantle.us-west-2.api.aws/v1',
+                api_key='auto-generated-token',
                 default_headers=None,
             )
 
 
-@patch("fish_ai.engine.get_config")
+@patch('fish_ai.engine.get_config')
 def test_bedrock_uses_aws_profile_for_token(mock_get_config):
     def config_side_effect(key):
         config = {
-            "provider": "bedrock",
-            "aws_region": "us-west-2",
-            "aws_profile": "my-profile",
+            'provider': 'bedrock',
+            'aws_region': 'us-west-2',
+            'aws_profile': 'my-profile',
         }
         return config.get(key)
 
@@ -139,7 +139,7 @@ def test_bedrock_uses_aws_profile_for_token(mock_get_config):
     mock_session.get_credentials.return_value = mock_credentials
 
     mock_token_generator = MagicMock()
-    mock_token_generator.get_token.return_value = "profile-token"
+    mock_token_generator.get_token.return_value = 'profile-token'
 
     mock_token_module = MagicMock()
     mock_token_module.BedrockTokenGenerator.return_value = mock_token_generator
@@ -150,23 +150,23 @@ def test_bedrock_uses_aws_profile_for_token(mock_get_config):
     with patch.dict(
         sys.modules,
         {
-            "aws_bedrock_token_generator": mock_token_module,
-            "botocore.session": mock_botocore_module,
-            "botocore": MagicMock(),
+            'aws_bedrock_token_generator': mock_token_module,
+            'botocore.session': mock_botocore_module,
+            'botocore': MagicMock(),
         },
     ):
-        with patch("openai.OpenAI") as mock_openai_cls:
+        with patch('openai.OpenAI') as mock_openai_cls:
             from fish_ai.engine import get_openai_client
 
             get_openai_client()
-            mock_botocore_module.Session.assert_called_once_with(profile="my-profile")
+            mock_botocore_module.Session.assert_called_once_with(profile='my-profile')
             mock_session.get_credentials.assert_called_once()
             mock_token_generator.get_token.assert_called_once_with(
                 credentials=mock_credentials,
-                region="us-west-2",
+                region='us-west-2',
             )
             mock_openai_cls.assert_called_once_with(
-                base_url="https://bedrock-mantle.us-west-2.api.aws/v1",
-                api_key="profile-token",
+                base_url='https://bedrock-mantle.us-west-2.api.aws/v1',
+                api_key='profile-token',
                 default_headers=None,
             )


### PR DESCRIPTION
## Summary

- Adds a new `aws_profile` configuration option for the Bedrock provider, allowing users to select a named profile from their AWS configuration (`~/.aws/credentials`, SSO, etc.)
- When `aws_profile` is set and no explicit `api_key` is provided, credentials are resolved from a profiled botocore session and used to generate the bearer token via `BedrockTokenGenerator`
- When `aws_profile` is omitted, the existing default credential chain behavior is preserved

## Configuration

```ini
[bedrock]
provider = bedrock
aws_region = us-east-1
aws_profile = my-profile
```

## Changes

- **`src/fish_ai/engine.py`** — Updated `get_openai_client()` Bedrock branch to check for `aws_profile` config, create a profiled `botocore.session.Session`, and generate the token from the resolved credentials
- **`src/fish_ai/tests/engine_test.py`** — Added `test_bedrock_uses_aws_profile_for_token` covering the profile-based credential flow
- **`README.md`** — Updated the Bedrock configuration example and documentation to include `aws_profile`