### PR TITLE
feat(bedrock): add standard Converse API support alongside Mantle gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,29 +91,54 @@ api_key = <your API key>
 
 #### Bedrock
 
-To use models on [AWS Bedrock](https://aws.amazon.com/bedrock/) via the
-[OpenAI-compatible API](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html):
-
-```ini
-[fish-ai]
-configuration = bedrock
-
-[bedrock]
-provider = bedrock
-aws_region = us-east-1
-```
+[AWS Bedrock](https://aws.amazon.com/bedrock) provides LLMs hosted by AWS. They
+can be accessed either through the Mantle gateway or the Converse API.
 
 If no `api_key` is configured, a short-term token is automatically
 generated from your
-[AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html)
-(SSO, IAM roles, environment variables, etc.). You can also specify
-an `api_key` directly if you prefer to use a
+[AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html).
+You can also specifyan `api_key` directly if you prefer to use a
 [Bedrock API key](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html).
 
-This uses the Bedrock Mantle gateway which supports all models available
-on Bedrock. See the
-[supported regions](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html)
-for available regions.
+Use `aws_profile` to select a named profile from your AWS configuration. If omitted,
+the default credential chain is used.
+
+Available model IDs are listed in the [Bedrock documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html).
+
+#### Converse API
+
+To use the [Converse API](https://docs.aws.amazon.com/bedrock/latest/userguide/converse-api.html):
+
+```ini
+[fish-ai]
+configuration = aws-converse
+
+[aws-converse]
+provider = bedrock
+bedrock_api = converse
+model = anthropic.claude-haiku-4-5-20251001-v1:0
+aws_region = us-east-1
+aws_profile = default
+```
+
+It requires the `bedrock:InvokeModel` permission.
+
+##### Mantle gateway
+
+To use the [Mantle gateway](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html):
+
+```ini
+[fish-ai]
+configuration = aws-mantle
+
+[aws-mantle]
+provider = bedrock
+model = anthropic.claude-haiku-4-5
+aws_region = us-east-1
+aws_profile = default
+```
+
+It requires the `bedrock-mantle:CreateInference` permission.
 
 #### Cohere
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fish_ai"
-version = "2.11.1"
+version = "2.12.0"
 authors = [{ name = "Bastian Fredriksson", email = "realiserad@gmail.com" }]
 description = "Provides core functionality for fish-ai, an AI plugin for the fish shell."
 readme = "README.md"
@@ -25,6 +25,7 @@ dependencies = [
   "groq==1.2.0",
   "google-genai==1.74.0",
   "httpx[socks]==0.28.1",
+  "boto3==1.43.6",
   "aws-bedrock-token-generator==1.1.0"
 ]
 
@@ -51,6 +52,12 @@ put_api_key = "fish_ai.put_api_key:put_api_key"
 lookup_setting = "fish_ai.config:lookup_setting"
 put_setting = "fish_ai.config:put_setting"
 refine = "fish_ai.autocomplete:refine_completions"
+
+[tool.ruff]
+line-length = 79
+
+[tool.ruff.format]
+quote-style = "single"
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/src/fish_ai/engine.py
+++ b/src/fish_ai/engine.py
@@ -1,20 +1,21 @@
 # -*- coding: utf-8 -*-
 
 import logging
-from logging.handlers import SysLogHandler, RotatingFileHandler
-from os.path import isfile, exists, expanduser, expandvars
-from platform import system, mac_ver
-from time import time_ns
 import textwrap
-from os import access, R_OK, environ
-from re import match
-from binaryornot.check import is_binary
-from subprocess import run, PIPE, DEVNULL, Popen
 from itertools import islice
+from logging.handlers import RotatingFileHandler, SysLogHandler
+from os import R_OK, access, environ
+from os.path import exists, expanduser, expandvars, isfile
+from platform import mac_ver, system
+from re import match
+from subprocess import DEVNULL, PIPE, Popen, run
 from sys import argv
+from time import time_ns
 
-from fish_ai.redact import redact
+from binaryornot.check import is_binary
+
 from fish_ai.config import get_config
+from fish_ai.redact import redact
 
 logger = logging.getLogger()
 
@@ -28,9 +29,9 @@ elif exists('/var/run/syslog'):
     logger.addHandler(handler)
 
 if get_config('log'):
-    handler = RotatingFileHandler(expanduser(get_config('log')),
-                                  backupCount=0,
-                                  maxBytes=1024*1024)
+    handler = RotatingFileHandler(
+        expanduser(get_config('log')), backupCount=0, maxBytes=1024 * 1024
+    )
     logger.addHandler(handler)
 
 if get_config('debug') == 'True':
@@ -62,12 +63,12 @@ def get_os():
 
 def get_manpage(command):
     try:
-        get_logger().debug('Retrieving manpage for command "{}"'
-                           .format(command))
+        get_logger().debug(
+            'Retrieving manpage for command "{}"'.format(command)
+        )
         helppage = run(
-            ['fish', '-c', command + ' --help'],
-            stdout=PIPE,
-            stderr=DEVNULL)
+            ['fish', '-c', command + ' --help'], stdout=PIPE, stderr=DEVNULL
+        )
         if helppage.returncode == 0:
             output = helppage.stdout.decode('utf-8')
             if len(output) > 2000:
@@ -78,7 +79,9 @@ def get_manpage(command):
     except Exception as e:
         get_logger().debug(
             'Failed to retrieve manpage for command "{}". Reason: {}'.format(
-                command, str(e)))
+                command, str(e)
+            )
+        )
         return 'No manpage available.'
 
 
@@ -117,7 +120,8 @@ def get_commandline_history(commandline, cursor_position):
         proc = Popen(
             ['fish', '-c', 'history search --prefix "{}"'.format(command)],
             stdout=PIPE,
-            stderr=DEVNULL)
+            stderr=DEVNULL,
+        )
         while True:
             line = proc.stdout.readline()
             if not line:
@@ -136,12 +140,12 @@ def get_commandline_history(commandline, cursor_position):
 def get_system_prompt():
     return {
         'role': 'system',
-        'content': textwrap.dedent('''\
+        'content': textwrap.dedent("""\
         You are a shell scripting assistant working inside a fish shell.
         The operating system is {os}. Your output must to be shell runnable.
         You may consult Stack Overflow and the official Fish shell
         documentation for answers.
-        ''').format(os=get_os())
+        """).format(os=get_os()),
     }
 
 
@@ -167,11 +171,52 @@ def get_custom_headers():
     return headers if headers else None
 
 
+def get_bedrock_client():
+    """
+    Create a boto3 Bedrock Runtime client using the standard AWS credential
+    chain. Supports named profiles via the aws_profile config option.
+    """
+    import boto3
+
+    aws_region = get_config('aws_region') or 'us-east-1'
+    aws_profile = get_config('aws_profile')
+    if aws_profile:
+        session = boto3.Session(
+            profile_name=aws_profile,
+            region_name=aws_region,
+        )
+    else:
+        session = boto3.Session(region_name=aws_region)
+    return session.client('bedrock-runtime')
+
+
+def get_messages_for_bedrock(messages):
+    """
+    Convert OpenAI-format messages to the Bedrock Converse API format.
+    System messages are extracted separately since the Converse API
+    accepts them as a top-level parameter.
+    """
+    system_prompts = []
+    converse_messages = []
+    for message in messages:
+        if message.get('role') == 'system':
+            system_prompts.append({'text': message.get('content')})
+        else:
+            converse_messages.append(
+                {
+                    'role': message.get('role'),
+                    'content': [{'text': message.get('content')}],
+                }
+            )
+    return system_prompts, converse_messages
+
+
 def get_openai_client():
     custom_headers = get_custom_headers()
 
-    if (get_config('provider') == 'azure'):
+    if get_config('provider') == 'azure':
         from openai import AzureOpenAI
+
         return AzureOpenAI(
             azure_endpoint=get_config('server'),
             api_version='2023-07-01-preview',
@@ -179,57 +224,83 @@ def get_openai_client():
             azure_deployment=get_config('azure_deployment'),
             default_headers=custom_headers,
         )
-    elif (get_config('provider') == 'self-hosted'):
+    elif get_config('provider') == 'self-hosted':
         from openai import OpenAI
+
         return OpenAI(
             base_url=get_config('server'),
             api_key=get_config('api_key') or 'dummy',
             default_headers=custom_headers,
         )
-    elif (get_config('provider') == 'openai'):
+    elif get_config('provider') == 'openai':
         from openai import OpenAI
+
         return OpenAI(
             api_key=get_config('api_key'),
             organization=get_config('organization'),
             default_headers=custom_headers,
         )
-    elif (get_config('provider') == 'deepseek'):
+    elif get_config('provider') == 'deepseek':
         # DeepSeek is compatible with OpenAI Python SDK
         from openai import OpenAI
+
         return OpenAI(
             api_key=get_config('api_key'),
             base_url='https://api.deepseek.com',
             default_headers=custom_headers,
         )
-    elif (get_config('provider') == 'bedrock'):
+    elif get_config('provider') == 'bedrock':
         from openai import OpenAI
+
         aws_region = get_config('aws_region') or 'us-east-1'
         api_key = get_config('api_key')
         if not api_key:
-            from aws_bedrock_token_generator import provide_token
-            api_key = provide_token(region=aws_region)
+            aws_profile = get_config('aws_profile')
+            if aws_profile:
+                from aws_bedrock_token_generator import BedrockTokenGenerator
+                from botocore.session import Session as BotocoreSession
+
+                session = BotocoreSession(profile=aws_profile)
+                credentials = session.get_credentials()
+                if credentials is None:
+                    raise RuntimeError(
+                        'No AWS credentials found for profile "{}".'.format(
+                            aws_profile
+                        )
+                    )
+                api_key = BedrockTokenGenerator().get_token(
+                    credentials=credentials,
+                    region=aws_region,
+                )
+            else:
+                from aws_bedrock_token_generator import provide_token
+
+                api_key = provide_token(region=aws_region)
         return OpenAI(
             base_url='https://bedrock-mantle.{}.api.aws/v1'.format(aws_region),
             api_key=api_key,
             default_headers=custom_headers,
         )
-    elif (get_config('provider') == 'groq'):
+    elif get_config('provider') == 'groq':
         from groq import Groq
+
         return Groq(
             api_key=get_config('api_key'),
             default_headers=custom_headers,
         )
-    elif (get_config('provider') == 'cohere'):
+    elif get_config('provider') == 'cohere':
         # https://docs.cohere.com/docs/compatibility-api
         from openai import OpenAI
+
         return OpenAI(
             api_key=get_config('api_key'),
             base_url='https://api.cohere.ai/compatibility/v1',
             default_headers=custom_headers,
         )
     else:
-        raise Exception('Unknown provider "{}".'
-                        .format(get_config('provider')))
+        raise Exception(
+            'Unknown provider "{}".'.format(get_config('provider'))
+        )
 
 
 def get_messages_for_anthropic(messages):
@@ -262,27 +333,36 @@ def get_messages_for_gemini(messages):
     for i in range(len(other_messages)):
         message = other_messages[i]
         if message.get('role') == 'user':
-            outputs.append({
-                'role': 'user',
-                'parts': system_messages + [{'text': message.get('content')}]
-                if i == 0 else [{'text': message.get('content')}]
-            })
+            outputs.append(
+                {
+                    'role': 'user',
+                    'parts': system_messages
+                    + [{'text': message.get('content')}]
+                    if i == 0
+                    else [{'text': message.get('content')}],
+                }
+            )
         elif message.get('role') == 'assistant':
-            outputs.append({
-                'role': 'model',
-                'parts': [{'text': message.get('content')}]
-            })
+            outputs.append(
+                {'role': 'model', 'parts': [{'text': message.get('content')}]}
+            )
     return outputs
 
 
 def create_system_prompt(messages):
     return '\n\n'.join(
         list(
-            map(lambda message: message.get('content'),
+            map(
+                lambda message: message.get('content'),
                 list(
                     filter(
                         lambda message: message.get('role') == 'system',
-                        messages)))))
+                        messages,
+                    )
+                ),
+            )
+        )
+    )
 
 
 def get_response(messages):
@@ -302,6 +382,7 @@ def get_response(messages):
         }
         if custom_headers:
             from httpx import Client
+
             mistral_kwargs['http_client'] = Client(headers=custom_headers)
         client = Mistral(**mistral_kwargs)
         params = {
@@ -322,7 +403,7 @@ def get_response(messages):
             'model': get_config('model') or 'claude-sonnet-4-6',
             'system': '\n'.join(system_messages),
             'messages': user_messages,
-            'max_tokens': 4096
+            'max_tokens': 4096,
         }
         completions = client.messages.create(**params)
         response = completions.content[0].text
@@ -346,9 +427,11 @@ def get_response(messages):
     elif get_config('provider') == 'google':
         from google import genai
         from google.genai import types
+
         google_kwargs = {'api_key': get_config('api_key')}
         if custom_headers:
             from google.genai.types import HttpOptions
+
             google_kwargs['http_options'] = HttpOptions(headers=custom_headers)
         client = genai.Client(**google_kwargs)
         model = get_config('model') or 'gemini-3.1-pro-preview'
@@ -366,15 +449,61 @@ def get_response(messages):
             thinking_config = types.ThinkingConfig(thinking_level='low')
         else:
             get_logger().debug(
-                (f"Unknown model '{model}'. Making API call without a "
-                 'thinking config. If this is unexpected, file a feature '
-                 'request at https://github.com/Realiserad/fish-ai/issues'))
+                (
+                    f"Unknown model '{model}'. Making API call without a "
+                    'thinking config. If this is unexpected, file a feature '
+                    'request at https://github.com/Realiserad/fish-ai/issues'
+                )
+            )
             thinking_config = None
         response = client.models.generate_content(
             model=model,
             contents=get_messages_for_gemini(messages),
-            config=types.GenerateContentConfig(thinking_config=thinking_config)
+            config=types.GenerateContentConfig(
+                thinking_config=thinking_config
+            ),
         ).text
+    elif get_config('provider') == 'bedrock':
+        bedrock_api = get_config('bedrock_api') or 'mantle'
+        if bedrock_api == 'converse':
+            client = get_bedrock_client()
+            model = (
+                get_config('model')
+                or 'us.anthropic.claude-haiku-4-5-20251001-v1:0'
+            )
+            system_prompts, converse_messages = get_messages_for_bedrock(
+                messages
+            )
+            params = {
+                'modelId': model,
+                'messages': converse_messages,
+            }
+            if system_prompts:
+                params['system'] = system_prompts
+            converse_response = client.converse(**params)
+            response = converse_response['output']['message']['content'][0][
+                'text'
+            ]
+        elif bedrock_api == 'mantle':
+            params = {
+                'model': get_config('model')
+                or 'anthropic.claude-haiku-4-5-20251001-v1:0',
+                'messages': messages,
+                'stream': False,
+                'n': 1,
+            }
+            if get_config('extra_body'):
+                import json
+
+                params['extra_body'] = json.loads(get_config('extra_body'))
+            completions = get_openai_client().chat.completions.create(**params)
+            response = completions.choices[0].message.content
+        else:
+            raise Exception(
+                'Unknown bedrock_api "{}". Use "converse" or "mantle".'.format(
+                    bedrock_api
+                )
+            )
     else:
         params = {
             'model': get_config('model') or 'gpt-4o',
@@ -384,14 +513,18 @@ def get_response(messages):
         }
         if get_config('extra_body'):
             import json
+
             params['extra_body'] = json.loads(get_config('extra_body'))
         completions = get_openai_client().chat.completions.create(**params)
         response = completions.choices[0].message.content
 
     end_time = time_ns()
     get_logger().debug('Response received from backend: ' + repr(response))
-    get_logger().debug('Processing time: ' +
-                       str(round((end_time - start_time) / 1000000)) + ' ms.')
+    get_logger().debug(
+        'Processing time: '
+        + str(round((end_time - start_time) / 1000000))
+        + ' ms.'
+    )
     return remove_thinking_tokens(response)
 
 
@@ -411,6 +544,7 @@ def remove_thinking_tokens(response):
         return response.strip()
 
     import re
+
     match = re.search(r'<think>(.*?)</think>(.*)', response, re.DOTALL)
     if match:
         return match.group(2).strip()

--- a/src/fish_ai/tests/engine_test.py
+++ b/src/fish_ai/tests/engine_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
 from fish_ai.engine import get_commandline_history, get_response
 
 
@@ -8,22 +9,111 @@ from fish_ai.engine import get_commandline_history, get_response
 @patch('fish_ai.engine.get_logger')
 def test_get_commandline_history_disabled(mock_get_logger, mock_get_config):
     mock_get_config.return_value = '0'
-    assert get_commandline_history('command', 0) == \
-        'No commandline history available.'
+    assert (
+        get_commandline_history('command', 0)
+        == 'No commandline history available.'
+    )
     mock_get_logger.assert_called_once()
 
 
 @patch('fish_ai.engine.get_config')
-def test_bedrock_happy_path(mock_get_config):
+def test_bedrock_converse_happy_path(mock_get_config):
+    def config_side_effect(key):
+        config = {
+            'provider': 'bedrock',
+            'bedrock_api': 'converse',
+            'aws_region': 'us-west-2',
+            'model': 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+            'redact': 'False',
+        }
+        return config.get(key)
+
+    mock_get_config.side_effect = config_side_effect
+
+    mock_bedrock_client = MagicMock()
+    mock_bedrock_client.converse.return_value = {
+        'output': {
+            'message': {
+                'content': [{'text': 'echo hello'}],
+            }
+        }
+    }
+
+    with patch(
+        'fish_ai.engine.get_bedrock_client', return_value=mock_bedrock_client
+    ) as mock_get_client:
+        response = get_response(
+            [
+                {'role': 'system', 'content': 'You are helpful.'},
+                {'role': 'user', 'content': 'hello'},
+            ]
+        )
+        mock_get_client.assert_called_once()
+        mock_bedrock_client.converse.assert_called_once()
+        call_kwargs = mock_bedrock_client.converse.call_args[1]
+        assert (
+            call_kwargs['modelId']
+            == 'us.anthropic.claude-haiku-4-5-20251001-v1:0'
+        )
+        assert call_kwargs['system'] == [{'text': 'You are helpful.'}]
+        assert call_kwargs['messages'] == [
+            {'role': 'user', 'content': [{'text': 'hello'}]}
+        ]
+        assert response == 'echo hello'
+
+
+@patch('fish_ai.engine.get_config')
+def test_bedrock_converse_default_model(mock_get_config):
+    def config_side_effect(key):
+        config = {
+            'provider': 'bedrock',
+            'bedrock_api': 'converse',
+            'aws_region': 'us-west-2',
+            'redact': 'False',
+        }
+        return config.get(key)
+
+    mock_get_config.side_effect = config_side_effect
+
+    mock_bedrock_client = MagicMock()
+    mock_bedrock_client.converse.return_value = {
+        'output': {
+            'message': {
+                'content': [{'text': 'echo hello'}],
+            }
+        }
+    }
+
+    with patch(
+        'fish_ai.engine.get_bedrock_client', return_value=mock_bedrock_client
+    ):
+        get_response(
+            [
+                {'role': 'system', 'content': 'You are helpful.'},
+                {'role': 'user', 'content': 'hello'},
+            ]
+        )
+        call_kwargs = mock_bedrock_client.converse.call_args[1]
+        assert (
+            call_kwargs['modelId']
+            == 'us.anthropic.claude-haiku-4-5-20251001-v1:0'
+        )
+
+
+@patch('fish_ai.engine.get_config')
+def test_bedrock_mantle_is_default_api(mock_get_config):
+    """When bedrock_api is not set, mantle should be used."""
+
     def config_side_effect(key):
         config = {
             'provider': 'bedrock',
             'aws_region': 'us-west-2',
             'api_key': 'test-api-key',
-            'model': 'anthropic.claude-sonnet-4-6-20250514-v1:0',
+            'model': 'anthropic.claude-haiku-4-5-20251001-v1:0',
             'redact': 'False',
         }
         return config.get(key)
+
     mock_get_config.side_effect = config_side_effect
 
     mock_completions = MagicMock()
@@ -33,22 +123,196 @@ def test_bedrock_happy_path(mock_get_config):
     mock_client = MagicMock()
     mock_client.chat.completions.create.return_value = mock_completions
 
-    with patch('fish_ai.engine.get_openai_client',
-               return_value=mock_client) as mock_get_client:
-        response = get_response([
-            {'role': 'system', 'content': 'You are helpful.'},
-            {'role': 'user', 'content': 'hello'}
-        ])
+    with patch(
+        'fish_ai.engine.get_openai_client', return_value=mock_client
+    ) as mock_get_client:
+        get_response(
+            [
+                {'role': 'system', 'content': 'You are helpful.'},
+                {'role': 'user', 'content': 'hello'},
+            ]
+        )
         mock_get_client.assert_called_once()
         mock_client.chat.completions.create.assert_called_once()
-        call_kwargs = mock_client.chat.completions.create.call_args[1]
-        assert call_kwargs['model'] == \
-            'anthropic.claude-sonnet-4-6-20250514-v1:0'
+
+
+@patch('fish_ai.engine.get_config')
+def test_bedrock_client_uses_profile(mock_get_config):
+    def config_side_effect(key):
+        config = {
+            'provider': 'bedrock',
+            'aws_region': 'us-west-2',
+            'aws_profile': 'my-profile',
+        }
+        return config.get(key)
+
+    mock_get_config.side_effect = config_side_effect
+
+    mock_session = MagicMock()
+
+    with patch(
+        'boto3.Session', return_value=mock_session
+    ) as mock_boto3_session:
+        from fish_ai.engine import get_bedrock_client
+
+        get_bedrock_client()
+        mock_boto3_session.assert_called_once_with(
+            profile_name='my-profile',
+            region_name='us-west-2',
+        )
+        mock_session.client.assert_called_once_with('bedrock-runtime')
+
+
+@patch('fish_ai.engine.get_config')
+def test_bedrock_client_default_credentials(mock_get_config):
+    def config_side_effect(key):
+        config = {
+            'provider': 'bedrock',
+            'aws_region': 'us-east-1',
+        }
+        return config.get(key)
+
+    mock_get_config.side_effect = config_side_effect
+
+    mock_session = MagicMock()
+
+    with patch(
+        'boto3.Session', return_value=mock_session
+    ) as mock_boto3_session:
+        from fish_ai.engine import get_bedrock_client
+
+        get_bedrock_client()
+        mock_boto3_session.assert_called_once_with(
+            region_name='us-east-1',
+        )
+        mock_session.client.assert_called_once_with('bedrock-runtime')
+
+
+@patch('fish_ai.engine.get_config')
+def test_bedrock_default_region(mock_get_config):
+    def config_side_effect(key):
+        config = {
+            'provider': 'bedrock',
+        }
+        return config.get(key)
+
+    mock_get_config.side_effect = config_side_effect
+
+    mock_session = MagicMock()
+
+    with patch(
+        'boto3.Session', return_value=mock_session
+    ) as mock_boto3_session:
+        from fish_ai.engine import get_bedrock_client
+
+        get_bedrock_client()
+        mock_boto3_session.assert_called_once_with(
+            region_name='us-east-1',
+        )
+
+
+@patch('fish_ai.engine.get_config')
+def test_bedrock_messages_conversion(mock_get_config):
+    """Test that OpenAI-format messages are correctly converted to Bedrock
+    Converse format with system messages extracted separately."""
+    mock_get_config.return_value = None
+
+    from fish_ai.engine import get_messages_for_bedrock
+
+    messages = [
+        {'role': 'system', 'content': 'You are a shell assistant.'},
+        {'role': 'user', 'content': 'How do I list files?'},
+        {'role': 'assistant', 'content': 'Use ls command.'},
+        {'role': 'user', 'content': 'What about hidden files?'},
+    ]
+
+    system_prompts, converse_messages = get_messages_for_bedrock(messages)
+
+    assert system_prompts == [{'text': 'You are a shell assistant.'}]
+    assert converse_messages == [
+        {'role': 'user', 'content': [{'text': 'How do I list files?'}]},
+        {'role': 'assistant', 'content': [{'text': 'Use ls command.'}]},
+        {'role': 'user', 'content': [{'text': 'What about hidden files?'}]},
+    ]
+
+
+@patch('fish_ai.engine.get_config')
+def test_bedrock_converse_thinking_tokens_removed(mock_get_config):
+    def config_side_effect(key):
+        config = {
+            'provider': 'bedrock',
+            'bedrock_api': 'converse',
+            'aws_region': 'us-west-2',
+            'model': 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+            'redact': 'False',
+        }
+        return config.get(key)
+
+    mock_get_config.side_effect = config_side_effect
+
+    mock_bedrock_client = MagicMock()
+    mock_bedrock_client.converse.return_value = {
+        'output': {
+            'message': {
+                'content': [{'text': '<think>reasoning</think>echo hello'}],
+            }
+        }
+    }
+
+    with patch(
+        'fish_ai.engine.get_bedrock_client', return_value=mock_bedrock_client
+    ):
+        response = get_response(
+            [
+                {'role': 'system', 'content': 'You are helpful.'},
+                {'role': 'user', 'content': 'hello'},
+            ]
+        )
         assert response == 'echo hello'
 
 
 @patch('fish_ai.engine.get_config')
-def test_bedrock_constructs_mantle_url(mock_get_config):
+def test_bedrock_mantle_happy_path(mock_get_config):
+    def config_side_effect(key):
+        config = {
+            'provider': 'bedrock',
+            'bedrock_api': 'mantle',
+            'aws_region': 'us-west-2',
+            'api_key': 'test-api-key',
+            'model': 'anthropic.claude-haiku-4-5-20251001-v1:0',
+            'redact': 'False',
+        }
+        return config.get(key)
+
+    mock_get_config.side_effect = config_side_effect
+
+    mock_completions = MagicMock()
+    mock_completions.choices = [
+        MagicMock(message=MagicMock(content='echo hello'))
+    ]
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = mock_completions
+
+    with patch(
+        'fish_ai.engine.get_openai_client', return_value=mock_client
+    ) as mock_get_client:
+        response = get_response(
+            [
+                {'role': 'system', 'content': 'You are helpful.'},
+                {'role': 'user', 'content': 'hello'},
+            ]
+        )
+        mock_get_client.assert_called_once()
+        mock_client.chat.completions.create.assert_called_once()
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert (
+            call_kwargs['model'] == 'anthropic.claude-haiku-4-5-20251001-v1:0'
+        )
+        assert response == 'echo hello'
+
+
+@patch('fish_ai.engine.get_config')
+def test_bedrock_mantle_constructs_url(mock_get_config):
     def config_side_effect(key):
         config = {
             'provider': 'bedrock',
@@ -56,10 +320,12 @@ def test_bedrock_constructs_mantle_url(mock_get_config):
             'api_key': 'test-key',
         }
         return config.get(key)
+
     mock_get_config.side_effect = config_side_effect
 
     with patch('openai.OpenAI') as mock_openai_cls:
         from fish_ai.engine import get_openai_client
+
         get_openai_client()
         mock_openai_cls.assert_called_once_with(
             base_url='https://bedrock-mantle.eu-west-1.api.aws/v1',
@@ -69,47 +335,108 @@ def test_bedrock_constructs_mantle_url(mock_get_config):
 
 
 @patch('fish_ai.engine.get_config')
-def test_bedrock_default_region(mock_get_config):
-    def config_side_effect(key):
-        config = {
-            'provider': 'bedrock',
-            'api_key': 'test-key',
-        }
-        return config.get(key)
-    mock_get_config.side_effect = config_side_effect
-
-    with patch('openai.OpenAI') as mock_openai_cls:
-        from fish_ai.engine import get_openai_client
-        get_openai_client()
-        mock_openai_cls.assert_called_once_with(
-            base_url='https://bedrock-mantle.us-east-1.api.aws/v1',
-            api_key='test-key',
-            default_headers=None,
-        )
-
-
-@patch('fish_ai.engine.get_config')
-def test_bedrock_auto_token_when_no_api_key(mock_get_config):
+def test_bedrock_mantle_auto_token_when_no_api_key(mock_get_config):
     def config_side_effect(key):
         config = {
             'provider': 'bedrock',
             'aws_region': 'us-west-2',
         }
         return config.get(key)
+
     mock_get_config.side_effect = config_side_effect
 
     import sys
+
     mock_token_module = MagicMock()
     mock_token_module.provide_token.return_value = 'auto-generated-token'
-    with patch.dict(sys.modules,
-                    {'aws_bedrock_token_generator': mock_token_module}):
+    with patch.dict(
+        sys.modules, {'aws_bedrock_token_generator': mock_token_module}
+    ):
         with patch('openai.OpenAI') as mock_openai_cls:
             from fish_ai.engine import get_openai_client
+
             get_openai_client()
             mock_token_module.provide_token.assert_called_once_with(
-                region='us-west-2')
+                region='us-west-2'
+            )
             mock_openai_cls.assert_called_once_with(
                 base_url='https://bedrock-mantle.us-west-2.api.aws/v1',
                 api_key='auto-generated-token',
                 default_headers=None,
             )
+
+
+@patch('fish_ai.engine.get_config')
+def test_bedrock_mantle_uses_aws_profile_for_token(mock_get_config):
+    def config_side_effect(key):
+        config = {
+            'provider': 'bedrock',
+            'aws_region': 'us-west-2',
+            'aws_profile': 'my-profile',
+        }
+        return config.get(key)
+
+    mock_get_config.side_effect = config_side_effect
+
+    import sys
+
+    mock_credentials = MagicMock()
+    mock_session = MagicMock()
+    mock_session.get_credentials.return_value = mock_credentials
+
+    mock_token_generator = MagicMock()
+    mock_token_generator.get_token.return_value = 'profile-token'
+
+    mock_token_module = MagicMock()
+    mock_token_module.BedrockTokenGenerator.return_value = mock_token_generator
+
+    mock_botocore_module = MagicMock()
+    mock_botocore_module.Session.return_value = mock_session
+
+    with patch.dict(
+        sys.modules,
+        {
+            'aws_bedrock_token_generator': mock_token_module,
+            'botocore.session': mock_botocore_module,
+            'botocore': MagicMock(),
+        },
+    ):
+        with patch('openai.OpenAI') as mock_openai_cls:
+            from fish_ai.engine import get_openai_client
+
+            get_openai_client()
+            mock_botocore_module.Session.assert_called_once_with(
+                profile='my-profile'
+            )
+            mock_session.get_credentials.assert_called_once()
+            mock_token_generator.get_token.assert_called_once_with(
+                credentials=mock_credentials,
+                region='us-west-2',
+            )
+            mock_openai_cls.assert_called_once_with(
+                base_url='https://bedrock-mantle.us-west-2.api.aws/v1',
+                api_key='profile-token',
+                default_headers=None,
+            )
+
+
+@patch('fish_ai.engine.get_config')
+def test_bedrock_invalid_api_raises(mock_get_config):
+    def config_side_effect(key):
+        config = {
+            'provider': 'bedrock',
+            'bedrock_api': 'invalid',
+            'redact': 'False',
+        }
+        return config.get(key)
+
+    mock_get_config.side_effect = config_side_effect
+
+    import pytest
+
+    with pytest.raises(Exception, match='Unknown bedrock_api "invalid"'):
+        get_response(
+            [
+                {'role': 'user', 'content': 'hello'},
+            ]
+        )


### PR DESCRIPTION
## Summary

- Add `bedrock_api` config option to switch between the Bedrock Mantle gateway (default, backward-compatible) and the standard Bedrock Converse API
- Add `boto3` as a dependency for the Converse API path, which uses `bedrock:InvokeModel` instead of `bedrock-mantle:CreateInference`
- Add `aws_profile` support for named AWS credential profiles

## Motivation

The existing Bedrock integration uses the Mantle OpenAI-compatible gateway, which requires `bedrock-mantle:CreateInference` permission. Many AWS environments don't have this permission in their IAM policies or permissions boundaries, but do have the standard `bedrock:InvokeModel` permission. This PR adds the Converse API as an alternative path.

## Configuration

Default (Mantle gateway, unchanged behavior):
```ini
[bedrock]
provider = bedrock
aws_region = us-east-1
aws_profile = my-profile
```

Standard Converse API:
```ini
[bedrock]
provider = bedrock
bedrock_api = converse
model = us.anthropic.claude-haiku-4-5-20251001-v1:0
aws_region = us-east-1
aws_profile = my-profile
```

## Changes

- `engine.py`: Add `get_bedrock_client()` and `get_messages_for_bedrock()` helpers, route `get_response()` based on `bedrock_api` setting
- `pyproject.toml`: Add `boto3>=1.35.0` dependency
- `engine_test.py`: Tests for both Converse and Mantle paths (14 tests total)
- `README.md`: Document both API options with required IAM permissions