### PR TITLE
ci: remove gates for pre-commit bot and make python tests work on forks

### DIFF
--- a/.github/workflows/automerge-dependency-updates.yaml
+++ b/.github/workflows/automerge-dependency-updates.yaml
@@ -19,12 +19,3 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  pre-commit-ci:
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'pre-commit-ci[bot]'
-    steps:
-      - name: Automerge PR
-        run: gh pr merge --auto --rebase "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -18,17 +18,18 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
-      - name: Set up Python ${{ matrix.python-version }}
-        run: |
-          uv sync --python ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Run tests
         run: |
-          uv coverage run --branch --include="src/fish_ai/*.py" -m pytest
-          uv coverage xml
-          uv coverage report
+          uv run coverage run --branch --include="src/fish_ai/*.py" -m pytest
+          uv run coverage xml
+          uv run coverage report
       - name: Report code coverage
-        if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'pre-commit-ci[bot]'
+        if: >
+          github.event.pull_request.user.login != 'dependabot[bot]' &&
+          github.repository == 'realiserad/fish-ai'
         uses: orgoro/coverage@v3.3
         with:
           coverageFile: coverage.xml


### PR DESCRIPTION
The pre-commit CI app is no longer active on this repository, so there should be no need to check for this in the GitHub Actions workflows.

Also, the step that sets up `uv` for Python testing is broken, the correct YAML is described [here](https://github.com/astral-sh/setup-uv).