### PR TITLE
Resolve Python problems flagged by basedpyright

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -25,6 +25,13 @@ hooks = [
 ]
 
 [[repos]]
+repo = "https://github.com/DetachHead/basedpyright-prek-mirror"
+rev = "1.39.3"
+hooks = [
+  { id = "basedpyright" },
+]
+
+[[repos]]
 repo = "https://github.com/crate-ci/typos"
 rev = "v1.46.1"
 hooks = [


### PR DESCRIPTION
Zed uses basedpyright for static type checking and it produces a bunch of squiggly lines in the editor which makes it difficult to detect new issues.

Begin by adding the [prek commit hook for basedpyright](https://docs.basedpyright.com/latest/installation/prek-hook) to flag existing issues, and then resolve them one by one. Maybe AI can do this? I must be careful to not change any logic, presumably the code works as-is.

```
$ prek -a | grep -E 'warning:|error:' | wc -l
826
```

😢