### PR TITLE
feat: remove the provider for mistral ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,19 +201,6 @@ provider = groq
 api_key = <your API key>
 ```
 
-#### Mistral
-
-To use [Mistral](https://mistral.ai):
-
-```ini
-[fish-ai]
-configuration = mistral
-
-[mistral]
-provider = mistral
-api_key = <your API key>
-```
-
 #### OpenAI
 
 To use [OpenAI](https://platform.openai.com):

--- a/conf.d/fish_ai.fish
+++ b/conf.d/fish_ai.fish
@@ -122,6 +122,11 @@ function _fish_ai_update --on-event fish_ai_update
             echo "👋 Please specify the Cohere model you want to use in '$_fish_ai_config_path'."
         end
     end
+    # Upgrade to fish-ai 2.13.0
+    if grep -qE 'provider\s*=\s*"?mistral"?' "$_fish_ai_config_path"
+        echo "🍿 Migrating the Mistral AI provider to OpenAI SDK."
+        sed -i -E 's|^provider\s*=\s*"?mistral"?|provider = self-hosted\nserver = https://api.mistral.ai/v1|g' "$_fish_ai_config_path"
+    end
 
     _fish_ai_set_python_version
     if type -q uv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fish_ai"
-version = "2.12.2"
+version = "2.13.0"
 authors = [{ name = "Bastian Fredriksson", email = "realiserad@gmail.com" }]
 description = "Provides core functionality for fish-ai, an AI plugin for the fish shell."
 readme = "README.md"
@@ -18,9 +18,6 @@ dependencies = [
   "openai==2.34.0",
   "simple-term-menu==1.6.6",
   "iterfzf==1.9.0.67.0",
-  # TODO: Temporarily disabled due to being quarantined by PyPi
-  # See: https://github.com/Realiserad/fish-ai/issues/613
-  #"mistralai==2.4.4",
   "binaryornot==0.6.0",
   "anthropic==0.98.1",
   "keyring==25.7.0",


### PR DESCRIPTION
This makes it possible to drop the mistralai dependency from `pyproject.toml`. Mistral users are automatically migrated to the OpenAI SDK with the official Mistral AI endpoint.

See #613.