### PR TITLE
fix: use a single system message

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fish_ai"
-version = "2.13.0"
+version = "2.13.1"
 authors = [{ name = "Bastian Fredriksson", email = "realiserad@gmail.com" }]
 description = "Provides core functionality for fish-ai, an AI plugin for the fish shell."
 readme = "README.md"

--- a/src/fish_ai/autocomplete.py
+++ b/src/fish_ai/autocomplete.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from fish_ai import engine
-from iterfzf import iterfzf
 import textwrap
+from base64 import b64decode, b64encode
+from subprocess import DEVNULL, PIPE, run
+
+from iterfzf import iterfzf
+
+from fish_ai import engine
 from fish_ai.config import get_config
-from subprocess import run, PIPE, DEVNULL
-from base64 import b64encode, b64decode
 
 
 def get_instructions(
@@ -182,11 +184,13 @@ def get_pipe(buffer):
 def get_messages(
     commandline, cursor_position, completions_count, additional_instructions
 ):
-    return [engine.get_system_prompt()] + get_instructions(
-        commandline=commandline,
-        cursor_position=cursor_position,
-        completions_count=completions_count,
-        additional_instructions=additional_instructions,
+    return engine.get_messages(
+        get_instructions(
+            commandline=commandline,
+            cursor_position=cursor_position,
+            completions_count=completions_count,
+            additional_instructions=additional_instructions,
+        )
     )
 
 

--- a/src/fish_ai/codify.py
+++ b/src/fish_ai/codify.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from fish_ai import engine
 import textwrap
+
+from fish_ai import engine
 
 
 def get_instructions(commandline):
@@ -42,7 +43,7 @@ def get_instructions(commandline):
 
 
 def get_messages(commandline):
-    return [engine.get_system_prompt()] + get_instructions(commandline)
+    return engine.get_messages(get_instructions(commandline))
 
 
 def codify():

--- a/src/fish_ai/engine.py
+++ b/src/fish_ai/engine.py
@@ -150,6 +150,13 @@ def get_system_prompt():
     }
 
 
+def get_messages(instructions):
+    instructions[0]["content"] = (
+        get_system_prompt()["content"] + "\n\n" + instructions[0]["content"]
+    )
+    return instructions
+
+
 def get_custom_headers():
     """
     Parse custom headers from config.

--- a/src/fish_ai/explain.py
+++ b/src/fish_ai/explain.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from fish_ai import engine
 import textwrap
+
+from fish_ai import engine
 
 
 def get_instructions(commandline):
@@ -43,7 +44,7 @@ def get_instructions(commandline):
 
 
 def get_messages(commandline):
-    return [engine.get_system_prompt()] + get_instructions(commandline)
+    return engine.get_messages(get_instructions(commandline))
 
 
 def explain():

--- a/src/fish_ai/fix.py
+++ b/src/fish_ai/fix.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
 import subprocess
-from fish_ai import engine
 import textwrap
+
+from fish_ai import engine
 
 
 def get_instructions(command, error_message):
@@ -56,9 +57,7 @@ def get_instructions(command, error_message):
 
 
 def get_messages(command, error_message):
-    return [engine.get_system_prompt()] + get_instructions(
-        command, error_message
-    )
+    return engine.get_messages(get_instructions(command, error_message))
 
 
 def get_error_message(previous_command):

--- a/src/fish_ai/tests/engine_test.py
+++ b/src/fish_ai/tests/engine_test.py
@@ -2,7 +2,29 @@
 
 from unittest.mock import MagicMock, patch
 
-from fish_ai.engine import get_commandline_history, get_response
+from fish_ai.engine import (
+    get_commandline_history,
+    get_messages,
+    get_response,
+)
+
+
+def test_get_messages():
+    instructions = [
+        {"role": "system", "content": "System message 1"},
+        {"role": "user", "content": "User message 1"},
+        {"role": "user", "content": "User message 2"},
+    ]
+    messages = get_messages(instructions)
+
+    assert len(messages) == 3
+    assert messages[0]["role"] == "system"
+    assert messages[0]["content"].__contains__(
+        "You are a shell scripting assistant working inside a fish shell."
+    )
+    assert messages[0]["content"].__contains__("System message 1")
+    assert messages[1]["role"] == "user"
+    assert messages[2]["role"] == "user"
 
 
 @patch("fish_ai.engine.get_config")


### PR DESCRIPTION
Some models (such as Qwen3) does not work with multiple system messages. `fish-ai` is currently using two system messages.

This PR changes the code to concatenate the system messages so instead of:

```
[
  { 
    role: system
    content: System message 1 
  },
  {
    role: system
    content: System message 2
  },
  {
    role: user
    content: User message
  }
]
```

it will use:

```
[
  { 
    role: system
    content: System message 1 | System message 2
  },
  {
    role: user
    content: User message
  }
]
```

Resolves: #622
