### PR TITLE
revert(deps): revert back to openai 2.53.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 dependencies = [
-  "openai==3.0.0",
+  "openai==2.53.0",
   "simple-term-menu==1.6.6",
   "iterfzf==1.9.0.67.0",
   "binaryornot==0.6.0",


### PR DESCRIPTION
Reverts #755.

I need to look at how the switch to `httpx2` affects the codebase.